### PR TITLE
fix: preserve popup owner and release 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agents-mon"
-version = "0.1.16"
+version = "0.2.0"
 dependencies = [
  "libc",
  "mac-usernotifications",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agents-mon"
-version = "0.1.16"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/src/toggle.rs
+++ b/src/toggle.rs
@@ -127,7 +127,7 @@ fn select_sidebar(client: Option<&str>) {
     let _ = tmux::command_status(&["switch-client", "-c", client, "-T", "agents-mon"]);
 }
 
-fn popup(plugin_dir: &Path, mut client: Option<String>) -> i32 {
+fn popup(plugin_dir: &Path, client: Option<String>) -> i32 {
     let pin = std::env::temp_dir().join("agents-mon-pin");
     if pin.exists() {
         let _ = std::fs::remove_file(pin);
@@ -175,10 +175,14 @@ fn popup(plugin_dir: &Path, mut client: Option<String>) -> i32 {
             let target = std::fs::read_to_string(&jump).unwrap_or_default();
             let target = target.trim();
             let _ = std::fs::remove_file(&jump);
-            client = panes::newest_real_client("#{client_name}").ok().flatten();
             if !target.is_empty() {
-                if let Some(owner) = client.as_deref() {
-                    let _ = tmux::command_status(&["switch-client", "-c", owner, "-t", target]);
+                let Some(owner) = client.as_deref() else {
+                    let _ = std::fs::remove_file(&pin);
+                    break;
+                };
+                if tmux::command_status(&["switch-client", "-c", owner, "-t", target]).is_err() {
+                    let _ = std::fs::remove_file(&pin);
+                    break;
                 }
                 let _ = tmux::command_status(&["select-window", "-t", target]);
                 let _ = tmux::command_status(&["select-pane", "-t", target]);

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -479,13 +479,15 @@ SH
   TMUX_STUB_LOG="$tmp/tmux.log" TMPDIR="$tmp" PATH="$tmp/bin:$PATH" \
     "$BIN" toggle popup popup-client
   popups="$(grep -c '^display-popup' "$tmp/tmux.log")"
-  if [ "$popups" -eq 2 ] &&
-    grep -Fq 'switch-client -c newest-client -t %42' "$tmp/tmux.log" &&
+  owner_popups="$(grep '^display-popup' "$tmp/tmux.log" | grep -Fc -- '-c popup-client')"
+  if [ "$popups" -eq 2 ] && [ "$owner_popups" -eq 2 ] &&
+    grep -Fq 'switch-client -c popup-client -t %42' "$tmp/tmux.log" &&
+    ! grep -Fq 'switch-client -c newest-client' "$tmp/tmux.log" &&
     grep -Fq 'select-window -t %42' "$tmp/tmux.log" &&
     grep -Fq 'select-pane -t %42' "$tmp/tmux.log"; then
-    echo "ok   popup-jump-reopens-over-target"
+    echo "ok   popup-jump-keeps-owner"
   else
-    echo "FAIL popup-jump-reopens-over-target"
+    echo "FAIL popup-jump-keeps-owner"
     cat "$tmp/tmux.log"
     fail=1
   fi


### PR DESCRIPTION
## Summary

- preserve the popup owner across native toggles
- add regression coverage for popup ownership
- bump the plugin version to 0.2.0

## Validation

- `cargo test --locked`
- `./tests/run.sh`