### PR TITLE
chore: bump version to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agents-mon"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "libc",
  "mac-usernotifications",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agents-mon"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Version bump to 0.2.1 following the working-detection fix (PR #14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PVVZPyA4qLbwMrdXhEwTKV