### PR TITLE
chore: publish curated release notes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,6 +130,8 @@ jobs:
       - name: Create checksums
         shell: bash
         run: |
+          tar -xOf dist/tmux-agents-mon-linux-x86_64.tar.gz \
+            tmux-agents-mon-linux-x86_64/RELEASE_NOTES.md > RELEASE_NOTES.md
           count="$(find dist -maxdepth 1 -name 'tmux-agents-mon-*.tar.gz' | wc -l)"
           test "$count" -eq 4
           cd dist
@@ -147,6 +149,6 @@ jobs:
             dist/*.tar.gz dist/SHA256SUMS \
             --draft \
             --verify-tag \
-            --generate-notes \
+            --notes-file RELEASE_NOTES.md \
             --title "tmux-agents-mon $GITHUB_REF_NAME"
           gh release edit "$GITHUB_REF_NAME" --draft=false

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,6 @@ install-app:
 release:
 	./scripts/release.sh
 
-# patch-bump Cargo.toml, run both suites, commit + tag (no push)
+# update RELEASE_NOTES.md, then patch-bump, test, commit, and tag (no push)
 bump:
 	./scripts/bump.sh

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,25 @@
+# tmux-agents-mon v0.2.1
+
+## What's changed
+
+### Fixes
+
+- Improved Claude working-state detection for live activity lines ([#14](https://github.com/snirt/tmux-agents-mon/pull/14)).
+- Fixed concurrent macOS notifications with a shared broker ([#18](https://github.com/snirt/tmux-agents-mon/pull/18)).
+- Improved notification authorization, click handling, retries, and shutdown behavior.
+
+### Release tooling
+
+- Added safer version bump and release scripts.
+- Added release-process tests and stronger tmux sanity checks.
+- Updated version to `0.2.1` ([#19](https://github.com/snirt/tmux-agents-mon/pull/19)).
+
+### Assets
+
+- Linux x86_64
+- Linux aarch64
+- macOS x86_64
+- macOS aarch64
+- SHA-256 checksums
+
+**Full changelog:** <https://github.com/snirt/tmux-agents-mon/compare/v0.2.0...v0.2.1>

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Patch-bump Cargo.toml, verify, commit, and tag locally.
+# Patch-bump Cargo.toml, verify, commit updated release notes, and tag locally.
 set -euo pipefail
 
 DIR="$(cd "$(dirname "$0")/.." && pwd)"
@@ -10,7 +10,7 @@ sed -i.bak "s/^version = \"$old\"/version = \"$new\"/" Cargo.toml
 rm Cargo.toml.bak
 cargo test
 ./tests/run.sh
-git add Cargo.toml Cargo.lock
+git add Cargo.toml Cargo.lock RELEASE_NOTES.md
 git commit -m "chore: bump version to $new"
 git tag "v$new"
 echo "bumped $old -> $new, tagged v$new (not pushed)"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -28,6 +28,11 @@ git merge-base --is-ancestor origin/master HEAD || {
   echo 'release requires exactly one local bump commit' >&2
   exit 1
 }
+if [ ! -s RELEASE_NOTES.md ] ||
+  git diff --quiet origin/master..HEAD -- RELEASE_NOTES.md; then
+  echo 'release requires updated RELEASE_NOTES.md' >&2
+  exit 1
+fi
 [ "$(git log -1 --pretty=%s)" = "chore: bump version to $version" ] || {
   echo 'release requires the version bump commit at HEAD' >&2
   exit 1

--- a/tests/make-release.sh
+++ b/tests/make-release.sh
@@ -17,7 +17,8 @@ cp "$DIR/Makefile" "$work/Makefile"
 cp "$DIR/scripts/version.sh" "$DIR/scripts/release.sh" "$work/scripts/"
 chmod +x "$work/scripts/version.sh" "$work/scripts/release.sh"
 printf '[package]\nname = "agents-mon"\nversion = "0.2.0"\n' >"$work/Cargo.toml"
-git -C "$work" add Makefile Cargo.toml scripts/version.sh scripts/release.sh
+printf '0.2.0 notes\n' >"$work/RELEASE_NOTES.md"
+git -C "$work" add Makefile Cargo.toml RELEASE_NOTES.md scripts/version.sh scripts/release.sh
 git -C "$work" commit -qm initial
 git -C "$work" push -q -u origin master
 
@@ -48,6 +49,20 @@ rm "$work/untracked"
 sed -i.bak 's/version = "0.2.0"/version = "0.2.1"/' "$work/Cargo.toml"
 rm "$work/Cargo.toml.bak"
 git -C "$work" commit -qam 'chore: bump version to 0.2.1'
+git -C "$work" tag v0.2.1
+if make -s -C "$work" release >"$tmp/notes.out" 2>&1; then
+  echo 'FAIL make-release: unchanged release notes were published'
+  exit 1
+fi
+grep -Fq 'release requires updated RELEASE_NOTES.md' "$tmp/notes.out" || {
+  cat "$tmp/notes.out"
+  echo 'FAIL make-release: unchanged notes failed without the release-notes guard'
+  exit 1
+}
+git -C "$work" tag -d v0.2.1 >/dev/null
+printf '0.2.1 notes\n' >"$work/RELEASE_NOTES.md"
+git -C "$work" add RELEASE_NOTES.md
+git -C "$work" commit -q --amend --no-edit
 git -C "$work" tag v0.2.1
 make -s -C "$work" release >"$tmp/release.out"
 


### PR DESCRIPTION
## Summary
- publish `RELEASE_NOTES.md` as GitHub release body
- require notes update in each version bump
- test stale release-note rejection

## Tests
- `make test`
- release-note archive extraction check
- LSP and pi-lens diagnostics