### PR TITLE
Add GitHub Pages landing site with animated demo

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,30 @@
+name: pages
+
+on:
+  push:
+    branches: [master]
+    paths: ['site/**', '.github/workflows/pages.yml']
+  workflow_dispatch:
+
+permissions:
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,570 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>tmux-agents-mon — monitor AI coding agents in tmux</title>
+<meta name="description" content="Monitor AI coding agents (Claude Code, Codex, OpenCode, Pi…) in your tmux panes — sidebar + status-line segment. No hooks, nothing runs inside your agents.">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav class="topnav">
+  <span class="brand">[agents-mon]</span>
+  <a href="#demo-section">0:demo</a>
+  <a href="#states">1:states</a>
+  <a href="#how">2:how</a>
+  <a href="#install">3:install</a>
+  <a href="#use">4:use</a>
+  <a href="#release">5:release</a>
+  <a class="ext" href="https://github.com/snirt/tmux-agents-mon">github ↗</a>
+</nav>
+
+<section class="hero">
+  <h1><span class="prompt">$</span> tmux-agents-mon</h1>
+  <p class="tagline">Every AI coding agent in your tmux, one glance.<br>
+  Who's <span class="c-red">blocked</span>, who's <span class="c-yellow">working</span>,
+  who's <span class="c-green">done</span> — without switching panes.</p>
+  <div class="badges">
+    <a href="https://github.com/snirt/tmux-agents-mon">github.com/snirt/tmux-agents-mon</a>
+    <span class="sep">·</span>
+    <a href="https://github.com/snirt/tmux-agents-mon/releases/latest"><span id="version">v0.2.1</span></a>
+    <span class="sep">·</span>
+    <span id="stars" hidden>★ <span id="star-count"></span></span>
+    <span>MIT</span>
+  </div>
+
+  <div class="demo-tabs" id="demo-section" role="tablist">
+    <button class="demo-tab active" data-demo="0">0:monitor</button>
+    <button class="demo-tab" data-demo="1">1:search</button>
+  </div>
+  <div class="term" aria-label="Animated mock of tmux with the agents sidebar">
+    <div class="term-bar">
+      <span class="dot d1"></span><span class="dot d2"></span><span class="dot d3"></span>
+      <span class="term-title">tmux</span>
+    </div>
+    <div class="term-top">
+      <span class="pill" id="top-pill">⧉ webapp</span>
+      <span class="wins" id="top-wins"><span class="win">vim <span class="badge b1">1</span></span>
+      <span class="win active">agents <span class="badge b2">2</span></span>
+      <span class="win">nu <span class="badge b3">3</span></span></span>
+      <span class="clock-wrap"><span id="clock">15:56</span></span>
+    </div>
+    <div class="term-body">
+      <div class="sidebar" id="demo">
+        <div class="pane-title">⤳ 1 agents-mon</div>
+        <div class="bar">agents<span class="bar-filter" id="bar-filter"></span></div>
+        <div class="hint" id="hint" hidden>↵ nav · ^u clear · esc clear</div>
+        <div class="session">webapp</div>
+        <div class="entry selected" data-state="working">
+          <div class="agent">
+            <span class="cursor">❯</span><span class="glyph spinner">⠹</span>
+            <span class="name">claude</span><span class="rest">1.2 ~/code/api</span>
+          </div>
+          <div class="title">fix flaky pane test</div>
+        </div>
+        <div class="entry" data-state="idle">
+          <div class="agent">
+            <span class="cursor">❯</span><span class="glyph">⣿</span>
+            <span class="name">codex</span><span class="rest">2.1 ~/code/web</span>
+          </div>
+        </div>
+        <div class="session">oss</div>
+        <div class="entry" data-state="blocked">
+          <div class="agent">
+            <span class="cursor">❯</span><span class="glyph">⣿</span>
+            <span class="name">opencode</span><span class="rest">1.2 ~/oss/mon</span>
+          </div>
+          <div class="title">allow shell command?</div>
+        </div>
+        <div class="entry" data-state="working">
+          <div class="agent">
+            <span class="cursor">❯</span><span class="glyph spinner">⣤</span>
+            <span class="name">pi</span><span class="rest">3.2 ~/oss/pi</span>
+          </div>
+          <div class="title">refactor detector</div>
+        </div>
+      </div>
+      <div class="pane-wrap">
+        <div class="pane-title" id="pane-title">⤳ 2 ✳ claude</div>
+        <div class="pane" id="pane"></div>
+      </div>
+    </div>
+    <div class="key-osd" id="key-osd" hidden></div>
+  </div>
+
+  <p class="demo-caption" id="demo-caption">every agent's state at a glance — jump to the blocked one and answer</p>
+
+  <p class="hero-install">
+    <span class="muted">install with <a href="https://github.com/tmux-plugins/tpm">TPM</a>:</span>
+  </p>
+  <pre class="hero-pre"><code>set -g @plugin 'snirt/tmux-agents-mon'</code></pre>
+</section>
+
+<main>
+
+<h2 id="states">states</h2>
+<div class="states">
+  <div class="row" data-state="blocked"><span class="glyph">⣿</span><span><b>blocked</b> — waiting for your input (permission prompt, menu)</span></div>
+  <div class="row" data-state="working"><span class="glyph spinner">⠹</span><span><b>working</b> — actively running</span></div>
+  <div class="row" data-state="done"><span class="glyph">⣿</span><span><b>done</b> — finished while you were elsewhere; clears when you view it</span></div>
+  <div class="row" data-state="idle"><span class="glyph">⣿</span><span><b>idle</b> — waiting at the prompt</span></div>
+</div>
+
+<h2 id="how">how it works</h2>
+<div class="traits">
+  <div class="trait">
+    <span class="trait-head">no hooks</span>
+    <p>Detection is scraping-only: agents are identified by walking each pane's
+    process tree, state inferred from the visible screen and title. Nothing
+    runs inside your agents.</p>
+  </div>
+  <div class="trait">
+    <span class="trait-head">six agents built in</span>
+    <p>Claude Code, Codex, Hermes, Oh My Pi, OpenCode, and Pi.
+    Adding an agent is one small config file — no code.</p>
+  </div>
+  <div class="trait">
+    <span class="trait-head">rust engine</span>
+    <p>A single daemon on one persistent tmux control-mode connection.
+    Prebuilt, verified binaries download automatically; Linux builds are
+    statically linked.</p>
+  </div>
+  <div class="trait">
+    <span class="trait-head">native notifications</span>
+    <p>macOS notifications via a signed <code>AgentsMon.app</code> — click one
+    and your terminal jumps to the exact pane. <code>notify-send</code> on
+    Linux.</p>
+  </div>
+</div>
+
+<h2 id="install">install</h2>
+<p>With <a href="https://github.com/tmux-plugins/tpm">TPM</a>:</p>
+<pre><code>set -g @plugin 'snirt/tmux-agents-mon'</code></pre>
+<p>Press <kbd>prefix + I</kbd>. That's it: the plugin downloads and verifies the
+Rust engine for your platform in the background.</p>
+<p>Or manually:</p>
+<pre><code>git clone https://github.com/snirt/tmux-agents-mon ~/.tmux/plugins/tmux-agents-mon
+echo "run-shell ~/.tmux/plugins/tmux-agents-mon/agents-mon.tmux" >> ~/.tmux.conf</code></pre>
+<p class="muted">Requirements: tmux and bash. <code>curl</code> and <code>tar</code>
+enable the automatic native download; without them, Cargo builds the engine when
+available. Release tarballs with <code>SHA256SUMS</code> are on the
+<a href="https://github.com/snirt/tmux-agents-mon/releases/latest">latest release</a>.</p>
+
+<h2 id="use">use it</h2>
+<ul>
+  <li><kbd>prefix + A</kbd> — toggle the sidebar (left split, or popup via
+      <code>@agents-mon-display 'popup'</code>)</li>
+  <li><kbd>j</kbd>/<kbd>k</kbd> move, <kbd>Enter</kbd> jumps to the selected
+      agent, <kbd>/</kbd> live search, <kbd>f</kbd> cycles the state filter,
+      <kbd>?</kbd> help</li>
+  <li>Click an agent row to jump to its pane; wheel scroll moves the cursor
+      (needs <code>set -g mouse on</code>)</li>
+  <li><kbd>u</kbd> opens the version picker — the plugin switches its source
+      <i>and</i> native engine to any release, and rolls back just as easily</li>
+</ul>
+<p>Add <code>#{agents_mon}</code> anywhere in your status line for the compact
+summary — e.g. <span style="white-space:nowrap"><span class="c-red">⣿1</span>
+<span class="c-yellow">⣾2</span>
+<span class="c-green">⣿1</span></span> for blocked/working/idle:</p>
+<pre><code>set -g status-right '#{agents_mon} | %H:%M'</code></pre>
+
+<h2 id="release">latest release</h2>
+<p id="release-head">
+  <span id="release-tag">v0.2.1</span>
+  <span id="release-date"></span>
+  <a href="https://github.com/snirt/tmux-agents-mon/releases">all releases →</a>
+</p>
+<pre id="release-notes" hidden><code id="release-body"></code></pre>
+
+<footer>
+  MIT © 2026 Snir Turgeman ·
+  <a href="https://github.com/snirt/tmux-agents-mon">source</a>
+</footer>
+
+</main>
+<script>
+// Spinner: the real SPIN frames from src/sidebar.rs.
+const SPIN = ['⠹', '⢸', '⣰', '⣤', '⣆', '⡇', '⠏', '⠛'];
+const reduced = matchMedia('(prefers-reduced-motion: reduce)').matches;
+let frame = 0;
+if (!reduced) {
+  setInterval(() => {
+    frame = (frame + 1) % SPIN.length;
+    document.querySelectorAll('.spinner').forEach((el, i) => {
+      el.textContent = SPIN[(frame + i * 3) % SPIN.length];
+    });
+  }, 120);
+}
+
+// The main pane mirrors the selected agent; `typed` is the answer being
+// typed into a blocked prompt.
+function paneLines(agent, state, typed) {
+  const wait = [['dim', '  ❯ waiting at prompt']];
+  switch (agent + '/' + state) {
+    case 'claude/working': return [
+      ['dim', '  Running tests…'],
+      ['yellow', '  ⠹ cargo test pane_lifecycle'],
+    ];
+    case 'claude/blocked': return [
+      ['box', '│ Edit tests/pane.rs?'],
+      ['box', '│ ❯ 1. Yes   2. No'], ['', ''],
+      ['dim', '> ' + typed + '▌'],
+    ];
+    case 'claude/done': return [
+      ['green', '  ✓ 42 tests passed'], ...wait,
+    ];
+    case 'opencode/blocked': return [
+      ['box', '│ $ cargo check'],
+      ['box', '│ Allow? [y/N] ' + typed + '▌'],
+    ];
+    case 'opencode/working': return [
+      ['yellow', '  ⠹ cargo check'],
+    ];
+    case 'pi/working': return [
+      ['yellow', '  ⠹ rewriting scan.rs'],
+    ];
+    case 'pi/done': return [
+      ['green', '  ✓ refactor complete'], ...wait,
+    ];
+    default: return wait;
+  }
+}
+const AGENTS = ['claude', 'codex', 'opencode', 'pi'];
+let sel = 0;
+let typed = '';
+function renderPane() {
+  const pane = document.getElementById('pane');
+  const state = rows[sel].dataset.state;
+  document.getElementById('pane-title').textContent = '⤳ 2 ✳ ' + AGENTS[sel];
+  pane.textContent = '';
+  paneLines(AGENTS[sel], state, typed).forEach(([cls, text]) => {
+    const line = document.createElement('div');
+    if (cls) line.className = 'l-' + cls;
+    // animate ⠹ in pane lines with the shared spinner interval
+    const at = text.indexOf('⠹');
+    if (at >= 0) {
+      line.appendChild(document.createTextNode(text.slice(0, at)));
+      const sp = document.createElement('span');
+      sp.className = 'spinner';
+      sp.textContent = '⠹';
+      line.appendChild(sp);
+      line.appendChild(document.createTextNode(text.slice(at + 1)));
+    } else {
+      line.textContent = text;
+    }
+    pane.appendChild(line);
+  });
+}
+
+// Status-line segment: live counts from the demo rows, same glyphs and
+// zero-count omission as status_segment() in src/scan.rs.
+const rows = document.querySelectorAll('#demo .entry');
+function renderSeg() {
+  const n = { blocked: 0, working: 0, idle: 0 };
+  rows.forEach(r => {
+    const s = r.dataset.state;
+    n[s === 'done' ? 'idle' : s]++;
+  });
+  const seg = document.getElementById('seg');
+  if (!seg) return;
+  seg.textContent = '';
+  [['blocked', 'c-red', '⣿'], ['working', 'c-yellow', '⣾'], ['idle', 'c-green', '⣿']]
+    .forEach(([k, cls, glyph]) => {
+      if (!n[k]) return;
+      const span = document.createElement('span');
+      span.className = cls;
+      span.textContent = ' ' + glyph;
+      seg.appendChild(span);
+      seg.appendChild(document.createTextNode(String(n[k])));
+    });
+}
+
+// Jumping to an agent switches the client to that agent's session, so the
+// status bar follows: session pill and window list per session.
+const SESSIONS = [
+  { name: 'webapp', wins: ['vim', 'agents', 'nu'] },
+  { name: 'oss', wins: ['docs', 'cargo', 'agents', 'git'] },
+];
+const ROW_SESSION = [0, 0, 1, 1];
+function renderTop() {
+  const s = SESSIONS[ROW_SESSION[sel]];
+  document.getElementById('top-pill').textContent = '⧉ ' + s.name;
+  const wins = document.getElementById('top-wins');
+  wins.textContent = '';
+  s.wins.forEach((w, k) => {
+    const span = document.createElement('span');
+    span.className = 'win' + (w === 'agents' ? ' active' : '');
+    span.textContent = w + ' ';
+    const badge = document.createElement('span');
+    badge.className = 'badge b' + (k + 1);
+    badge.textContent = k + 1;
+    span.appendChild(badge);
+    wins.appendChild(span);
+    wins.appendChild(document.createTextNode(' '));
+  });
+}
+
+// Pressed-key hint in the window's bottom-right, screencast style.
+function showKey(...keys) {
+  const osd = document.getElementById('key-osd');
+  osd.hidden = false;
+  osd.textContent = '';
+  keys.forEach((k, i) => {
+    if (i) osd.appendChild(document.createTextNode('/'));
+    const cap = document.createElement('span');
+    cap.className = 'key';
+    cap.textContent = k;
+    osd.appendChild(cap);
+  });
+  osd.classList.remove('pop');
+  void osd.offsetWidth;
+  osd.classList.add('pop');
+}
+
+// Scenario helpers: move the cursor, flip a state, type an answer.
+// Moves show both bindings — vim key and arrow both work in the sidebar.
+function select(i, quiet) {
+  if (!quiet) showKey(i > sel ? 'j' : 'k', i > sel ? '↓' : '↑');
+  rows[sel].classList.remove('selected');
+  sel = i;
+  typed = '';
+  rows[sel].classList.add('selected');
+  // viewing a done agent clears it, like the real sidebar
+  if (rows[sel].dataset.state === 'done') setState(sel, 'idle');
+  renderTop();
+  renderPane();
+}
+function setState(i, state, title) {
+  rows[i].dataset.state = state;
+  const t = rows[i].querySelector('.title');
+  if (t && title !== undefined) t.textContent = title;
+  rows[i].querySelector('.glyph').classList.toggle('spinner', state === 'working');
+  if (state !== 'working') rows[i].querySelector('.glyph').textContent = '⣿';
+  if (i === sel) renderPane();
+  renderSeg();
+}
+function typeIn(text, done) {
+  let k = 0;
+  const g = gen;                    // a demo switch cancels in-flight typing
+  (function next() {
+    if (g !== gen) return;
+    showKey(text[k]);
+    typed += text[k++];
+    renderPane();
+    if (k < text.length) setTimeout(next, 160);
+    else if (done) setTimeout(done, 350);
+  })();
+}
+
+// Live search: header shows /query with match counts, list filters,
+// hint line appears — like the real `/` mode.
+const sessionHeads = document.querySelectorAll('#demo .session');
+function applyFilter(q) {
+  const bar = document.getElementById('bar-filter');
+  document.getElementById('hint').hidden = !q && q !== '';
+  let visible = 0;
+  rows.forEach((r, i) => {
+    const m = !q || AGENTS[i].includes(q);
+    r.hidden = !m;
+    if (m) visible++;
+  });
+  sessionHeads[0].hidden = !!q && rows[0].hidden && rows[1].hidden;
+  sessionHeads[1].hidden = !!q && rows[2].hidden && rows[3].hidden;
+  // counts appear only for a non-empty query, like the real header
+  bar.textContent = q === null ? '' : ' /' + q + (q ? ' ' + visible + '/' + rows.length : '');
+  if (q === null) document.getElementById('hint').hidden = true;
+}
+function typeSearch(query, done) {
+  let k = 0;
+  const g = gen;                    // a demo switch cancels in-flight typing
+  showKey('/');
+  applyFilter('');
+  (function next() {
+    if (g !== gen) return;
+    if (k < query.length) {
+      showKey(query[k]);
+      applyFilter(query.slice(0, ++k));
+      setTimeout(next, 260);
+    } else if (done) {
+      setTimeout(done, 500);
+    }
+  })();
+}
+
+// Demo carousel: two titled scenarios sharing the same mock window.
+const DEMOS = [
+  {
+    caption: "every agent's state at a glance — jump to the blocked one and answer",
+    steps: [
+      [2600, () => setState(0, 'blocked', 'Edit tests/pane.rs?')],
+      [1600, () => typeIn('1', () => setState(0, 'working', 'fix flaky pane test'))],
+      [2600, () => setState(2, 'blocked', 'allow shell command?')],
+      [1300, () => select(1)],
+      [900, () => select(2)],
+      [1300, () => typeIn('y', () => setState(2, 'working', 'run cargo check'))],
+      [2400, () => setState(3, 'done', 'refactor detector')],
+      [1500, () => select(3)],
+      [1600, () => select(0)],
+    ],
+  },
+  {
+    caption: 'find an agent instantly — / live search filters as you type',
+    steps: [
+      [1400, () => typeSearch('codex', () => select(1))],
+      [2600, () => { showKey('esc'); applyFilter(null); select(0, true); }],
+      [1400, () => typeSearch('pi', () => select(3))],
+      [2600, () => { showKey('esc'); applyFilter(null); }],
+    ],
+  },
+];
+let demo = 0, step = 0, timer = null, gen = 0;
+function resetDemo() {
+  gen++;
+  applyFilter(null);
+  setState(0, 'working', 'fix flaky pane test');
+  setState(1, 'idle');
+  setState(2, 'blocked', 'allow shell command?');
+  setState(3, 'working', 'refactor detector');
+  select(0, true);
+}
+function applyDemo(i) {
+  demo = i;
+  step = 0;
+  document.querySelectorAll('.demo-tab').forEach((t, k) => t.classList.toggle('active', k === i));
+  document.getElementById('demo-caption').textContent = DEMOS[i].caption;
+  resetDemo();
+  if (!reduced) run();
+}
+function startDemo(i, animate) {
+  clearTimeout(timer);
+  const t = document.querySelector('.term');
+  if (!animate || reduced) { applyDemo(i); return; }
+  // slide the window out one way, swap content, slide it in from the other
+  const dir = i > demo || (demo === DEMOS.length - 1 && i === 0) ? 1 : -1;
+  t.style.transition = 'transform 0.25s ease, opacity 0.25s ease';
+  t.style.transform = 'translateX(' + (-dir * 48) + 'px)';
+  t.style.opacity = '0';
+  gen++;                          // freeze the outgoing scenario mid-slide
+  setTimeout(() => {
+    applyDemo(i);
+    t.style.transition = 'none';
+    t.style.transform = 'translateX(' + (dir * 48) + 'px)';
+    void t.offsetWidth;
+    t.style.transition = 'transform 0.25s ease, opacity 0.25s ease';
+    t.style.transform = '';
+    t.style.opacity = '1';
+  }, 250);
+}
+function run() {
+  const steps = DEMOS[demo].steps;
+  const [delay, fn] = steps[step];
+  timer = setTimeout(() => {
+    fn();
+    step++;
+    if (step >= steps.length) {
+      timer = setTimeout(() => startDemo((demo + 1) % DEMOS.length, true), 2200);
+    } else {
+      run();
+    }
+  }, delay);
+}
+document.querySelectorAll('.demo-tab').forEach((t, i) =>
+  t.addEventListener('click', () => { if (i !== demo) startDemo(i, true); }));
+startDemo(0);
+
+// Clock in the mock status line.
+function clock() {
+  document.getElementById('clock').textContent =
+    new Date().toTimeString().slice(0, 5);
+}
+clock();
+setInterval(clock, 30000);
+
+// Scroll reveal: main-column blocks drift up as they enter the viewport.
+if (!reduced) {
+  const blocks = document.querySelectorAll('main > h2, main > div, main > p, main > pre, main > ul, main > footer');
+  const revealer = new IntersectionObserver(entries => {
+    entries.forEach(e => {
+      if (e.isIntersecting) {
+        e.target.classList.add('shown');
+        revealer.unobserve(e.target);
+      }
+    });
+  }, { rootMargin: '0px 0px -10% 0px' });
+  blocks.forEach(b => { b.classList.add('reveal'); revealer.observe(b); });
+}
+
+// Nav glow: highlight the section currently in view.
+const navLinks = [...document.querySelectorAll('.topnav a[href^="#"]')];
+const sections = navLinks.map(a => document.getElementById(a.hash.slice(1)));
+function markActive(id) {
+  navLinks.forEach(a => a.classList.toggle('active', a.hash === '#' + id));
+}
+const spy = new IntersectionObserver(entries => {
+  entries.forEach(e => { if (e.isIntersecting) markActive(e.target.id); });
+}, { rootMargin: '-20% 0px -70% 0px' });
+sections.forEach(s => spy.observe(s));
+navLinks.forEach(a => a.addEventListener('click', e => {
+  markActive(a.hash.slice(1));
+  a.blur();
+  const h = document.getElementById(a.hash.slice(1));
+  if (a.hash === '#demo-section') {
+    // the demo sits in the hero: center the mock window rather than
+    // pinning the tabs to the very top of the viewport
+    e.preventDefault();
+    document.querySelector('.term').scrollIntoView(
+      reduced ? { block: 'center' } : { behavior: 'smooth', block: 'center' });
+    return;
+  }
+  h.classList.remove('glance');
+  void h.offsetWidth;              // restart the animation on repeat clicks
+  h.classList.add('glance');
+}));
+
+// Copy buttons on code blocks.
+document.querySelectorAll('pre > code').forEach(code => {
+  if (code.id === 'release-body') return;
+  const btn = document.createElement('button');
+  btn.className = 'copy';
+  btn.textContent = 'copy';
+  btn.addEventListener('click', () => {
+    navigator.clipboard.writeText(code.textContent).then(() => {
+      btn.textContent = 'copied';
+      setTimeout(() => { btn.textContent = 'copy'; }, 1500);
+    });
+  });
+  code.parentElement.appendChild(btn);
+});
+
+// Live GitHub data. The page works without it; a fetch only upgrades it.
+const API = 'https://api.github.com/repos/snirt/tmux-agents-mon';
+function cachedJson(url) {
+  const hit = sessionStorage.getItem(url);
+  if (hit) return Promise.resolve(JSON.parse(hit));
+  return fetch(url).then(r => {
+    if (!r.ok) throw new Error(r.status);
+    return r.json().then(j => {
+      try { sessionStorage.setItem(url, JSON.stringify(j)); } catch (_) {}
+      return j;
+    });
+  });
+}
+cachedJson(API).then(repo => {
+  document.getElementById('star-count').textContent = repo.stargazers_count;
+  document.getElementById('stars').hidden = false;
+}).catch(() => {});
+cachedJson(API + '/releases/latest').then(rel => {
+  document.getElementById('version').textContent = rel.tag_name;
+  document.getElementById('release-tag').textContent = rel.tag_name;
+  document.getElementById('release-date').textContent =
+    new Date(rel.published_at).toISOString().slice(0, 10);
+  if (rel.body) {
+    // textContent, never innerHTML: the release body is remote markdown.
+    document.getElementById('release-body').textContent = rel.body.trim();
+    document.getElementById('release-notes').hidden = false;
+  }
+}).catch(() => {});
+</script>
+</body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -11,13 +11,13 @@
 
 <nav class="topnav">
   <span class="brand">[agents-mon]</span>
-  <a href="#demo-section">0:demo</a>
-  <a href="#states">1:states</a>
-  <a href="#how">2:how</a>
-  <a href="#install">3:install</a>
-  <a href="#use">4:use</a>
-  <a href="#release">5:release</a>
-  <a class="ext" href="https://github.com/snirt/tmux-agents-mon">github ↗</a>
+  <a href="#demo-section">demo</a>
+  <a href="#states">states</a>
+  <a href="#how">how</a>
+  <a href="#install">install</a>
+  <a href="#use">use</a>
+  <a href="#release">release</a>
+  <a class="ext" href="https://github.com/snirt/tmux-agents-mon" aria-label="GitHub repository"><svg viewBox="0 0 16 16" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg></a>
 </nav>
 
 <section class="hero">
@@ -30,13 +30,13 @@
     <span class="sep">·</span>
     <a href="https://github.com/snirt/tmux-agents-mon/releases/latest"><span id="version">v0.2.1</span></a>
     <span class="sep">·</span>
-    <span id="stars" hidden>★ <span id="star-count"></span></span>
+    <span id="stars" hidden><span class="star">★</span> <span id="star-count"></span></span>
     <span>MIT</span>
   </div>
 
   <div class="demo-tabs" id="demo-section" role="tablist">
-    <button class="demo-tab active" data-demo="0">0:monitor</button>
-    <button class="demo-tab" data-demo="1">1:search</button>
+    <button class="demo-tab active" data-demo="0">monitor</button>
+    <button class="demo-tab" data-demo="1">search</button>
   </div>
   <div class="term" aria-label="Animated mock of tmux with the agents sidebar">
     <div class="term-bar">
@@ -112,6 +112,7 @@
 </div>
 
 <h2 id="how">how it works</h2>
+<div class="traits-tabs" id="traits-tabs"></div>
 <div class="traits">
   <div class="trait">
     <span class="trait-head">no hooks</span>
@@ -152,17 +153,16 @@ available. Release tarballs with <code>SHA256SUMS</code> are on the
 <a href="https://github.com/snirt/tmux-agents-mon/releases/latest">latest release</a>.</p>
 
 <h2 id="use">use it</h2>
-<ul>
-  <li><kbd>prefix + A</kbd> — toggle the sidebar (left split, or popup via
-      <code>@agents-mon-display 'popup'</code>)</li>
-  <li><kbd>j</kbd>/<kbd>k</kbd> move, <kbd>Enter</kbd> jumps to the selected
-      agent, <kbd>/</kbd> live search, <kbd>f</kbd> cycles the state filter,
-      <kbd>?</kbd> help</li>
-  <li>Click an agent row to jump to its pane; wheel scroll moves the cursor
-      (needs <code>set -g mouse on</code>)</li>
-  <li><kbd>u</kbd> opens the version picker — the plugin switches its source
-      <i>and</i> native engine to any release, and rolls back just as easily</li>
-</ul>
+<div class="keys-table">
+  <div><span class="k"><kbd>prefix + A</kbd></span><span>toggle sidebar</span></div>
+  <div><span class="k"><kbd>j</kbd>/<kbd>k</kbd> <kbd>↑</kbd>/<kbd>↓</kbd></span><span>move</span></div>
+  <div><span class="k"><kbd>Enter</kbd></span><span>jump to agent</span></div>
+  <div><span class="k"><kbd>/</kbd></span><span>live search</span></div>
+  <div><span class="k"><kbd>f</kbd></span><span>state filter</span></div>
+  <div><span class="k"><kbd>u</kbd></span><span>version picker</span></div>
+  <div><span class="k"><kbd>?</kbd></span><span>help</span></div>
+  <div><span class="k">click / wheel</span><span>jump / scroll <span class="dim">(mouse)</span></span></div>
+</div>
 <p>Add <code>#{agents_mon}</code> anywhere in your status line for the compact
 summary — e.g. <span style="white-space:nowrap"><span class="c-red">⣿1</span>
 <span class="c-yellow">⣾2</span>
@@ -395,7 +395,7 @@ function typeSearch(query, done) {
 // Demo carousel: two titled scenarios sharing the same mock window.
 const DEMOS = [
   {
-    caption: "every agent's state at a glance — jump to the blocked one and answer",
+    caption: "every agent's state at a glance — vim motions (or arrows) to the blocked one, answer, done",
     steps: [
       [2600, () => setState(0, 'blocked', 'Edit tests/pane.rs?')],
       [1600, () => typeIn('1', () => setState(0, 'working', 'fix flaky pane test'))],
@@ -498,29 +498,84 @@ if (!reduced) {
 // Nav glow: highlight the section currently in view.
 const navLinks = [...document.querySelectorAll('.topnav a[href^="#"]')];
 const sections = navLinks.map(a => document.getElementById(a.hash.slice(1)));
+// each main block belongs to the section of its nearest preceding h2
+const mainBlocks = [...document.querySelector('main').children];
+{
+  let cur = '';
+  mainBlocks.forEach(el => {
+    if (el.tagName === 'H2' && el.id) cur = el.id;
+    el.dataset.sec = cur;
+  });
+}
 function markActive(id) {
   navLinks.forEach(a => a.classList.toggle('active', a.hash === '#' + id));
+  mainBlocks.forEach(el => el.classList.toggle('dim-sec', el.dataset.sec !== id));
 }
-const spy = new IntersectionObserver(entries => {
-  entries.forEach(e => { if (e.isIntersecting) markActive(e.target.id); });
-}, { rootMargin: '-20% 0px -70% 0px' });
-sections.forEach(s => spy.observe(s));
+// mark the last section whose heading is at/above the anchor landing line
+// (scroll-margin-top is 3rem, so 80px keeps short sections correct)
+function spy() {
+  if (hoverSec) { markActive(hoverSec); return; }
+  let active = 'demo-section';   // above everything = the hero demo
+  const y = innerHeight * 0.55;  // sections land centered, so spy mid-screen
+  sections.forEach(s => { if (s.getBoundingClientRect().top <= y) active = s.id; });
+  markActive(active);
+}
+addEventListener('scroll', spy, { passive: true });
+
+// the section under the mouse takes focus; scroll position is the fallback
+let hoverSec = '';
+const mainEl = document.querySelector('main');
+mainEl.addEventListener('mousemove', e => {
+  const el = e.target.closest('main > *');
+  const s = el && el.dataset.sec;
+  if (s && s !== hoverSec) { hoverSec = s; markActive(s); }
+});
+mainEl.addEventListener('mouseleave', () => { hoverSec = ''; spy(); });
+spy();
 navLinks.forEach(a => a.addEventListener('click', e => {
   markActive(a.hash.slice(1));
   a.blur();
   const h = document.getElementById(a.hash.slice(1));
+  e.preventDefault();
   if (a.hash === '#demo-section') {
-    // the demo sits in the hero: center the mock window rather than
-    // pinning the tabs to the very top of the viewport
-    e.preventDefault();
-    document.querySelector('.term').scrollIntoView(
-      reduced ? { block: 'center' } : { behavior: 'smooth', block: 'center' });
+    // the demo sits in the hero: go to the top of the page
+    scrollTo({ top: 0, behavior: reduced ? 'auto' : 'smooth' });
     return;
   }
+  // center the whole section (heading to next heading) in the viewport
+  const heads = sections.filter(s => s.tagName === 'H2');
+  const next = heads[heads.indexOf(h) + 1];
+  const bottom = next ? next.offsetTop : document.body.scrollHeight;
+  const top = h.offsetTop - Math.max((innerHeight - (bottom - h.offsetTop)) / 2, 48);
+  scrollTo({ top, behavior: reduced ? 'auto' : 'smooth' });
   h.classList.remove('glance');
   void h.offsetWidth;              // restart the animation on repeat clicks
   h.classList.add('glance');
 }));
+
+// How-it-works carousel: tabs built from the trait headings, auto-rotating.
+const traits = [...document.querySelectorAll('.traits .trait')];
+const traitTabsWrap = document.getElementById('traits-tabs');
+let ti = 0, ttimer = null;
+traits.forEach((t, i) => {
+  const b = document.createElement('button');
+  b.className = 'trait-tab';
+  b.textContent = t.querySelector('.trait-head').textContent;
+  b.addEventListener('click', () => { showTrait(i); traitLoop(); });
+  traitTabsWrap.appendChild(b);
+});
+function showTrait(i) {
+  ti = i;
+  traits.forEach((t, k) => t.classList.toggle('active', k === i));
+  traitTabsWrap.querySelectorAll('.trait-tab').forEach((b, k) =>
+    b.classList.toggle('active', k === i));
+}
+function traitLoop() {
+  clearInterval(ttimer);
+  if (!reduced) ttimer = setInterval(() => showTrait((ti + 1) % traits.length), 8000);
+}
+showTrait(0);
+traitLoop();
 
 // Copy buttons on code blocks.
 document.querySelectorAll('pre > code').forEach(code => {

--- a/site/style.css
+++ b/site/style.css
@@ -27,7 +27,7 @@ html { scroll-behavior: smooth; }
 .reveal {
   opacity: 0;
   transform: translateY(14px);
-  transition: opacity 0.45s ease, transform 0.45s ease;
+  transition: opacity 0.45s ease, transform 0.45s ease, filter 0.35s ease-in-out;
 }
 .reveal.shown { opacity: 1; transform: none; }
 @media (prefers-reduced-motion: reduce) {
@@ -78,9 +78,14 @@ a:hover { text-decoration: underline; }
   color: var(--green);
   text-shadow: 0 0 8px rgba(108, 181, 108, 0.9), 0 0 20px rgba(108, 181, 108, 0.45);
 }
-.topnav .ext { margin-left: auto; color: var(--green); }
+.topnav .ext { margin-left: auto; color: var(--muted); display: flex; align-items: center; gap: 0.8ch; }
+.topnav .ext:hover { color: var(--fg); text-decoration: none; }
 
 h2[id], #demo-section { scroll-margin-top: 3rem; }
+
+/* out-of-focus sections fade back; filter keeps it independent of .reveal */
+main > * { transition: filter 0.35s ease-in-out; }
+main > .dim-sec { filter: opacity(0.55); }
 
 /* nav click: the target title flashes with a phosphor glow, then settles */
 @keyframes title-glow {
@@ -128,7 +133,15 @@ h1 .prompt { color: var(--green); }
   font-size: 0.85rem;
 }
 .badges .sep { color: var(--faint); }
-#stars[hidden] { display: none; }
+/* count stays on the row baseline; the star is nudged to optically match */
+#stars .star {
+  color: var(--yellow);
+  font-size: 2rem;
+  line-height: 0;
+  display: inline-block;
+  vertical-align: -0.16em;
+}
+#stars[hidden] { display: none !important; }
 
 .hero-install { margin: 2rem 0 0.4rem; font-size: 0.9rem; }
 .hero-pre {
@@ -160,7 +173,6 @@ h1 .prompt { color: var(--green); }
   color: var(--green);
   text-shadow: 0 0 8px rgba(108, 181, 108, 0.7);
 }
-.demo-tab.active::after { content: "*"; }
 
 .demo-caption {
   color: var(--muted);
@@ -403,24 +415,52 @@ p { margin: 0.7rem 0; }
 
 /* ---- trait grid ----------------------------------------------------- */
 
-.traits {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 0.8rem;
-  margin: 1rem 0;
+/* how-it-works carousel: one trait at a time, tabs above, slides in */
+.traits-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 1.4rem;
+  margin: 1rem 0 0.7rem;
 }
+.trait-tab {
+  background: none;
+  border: none;
+  font: inherit;
+  font-size: 0.95rem;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 0.1rem 0.2rem;
+}
+.trait-tab:hover { color: var(--fg); }
+.trait-tab.active {
+  color: var(--green);
+  text-shadow: 0 0 8px rgba(108, 181, 108, 0.7);
+}
+
+.traits { margin: 0 0 1rem; }
 .trait {
+  display: none;
   border: 1px solid var(--rule);
   border-radius: 4px;
-  padding: 0.6rem 0.9rem;
+  padding: 1rem 1.2rem;
   background: #121212;
+  height: 10.5rem;   /* fixed: no layout jump between slides */
+  overflow: hidden;
 }
-.trait-head { color: var(--green); font-weight: 600; }
-.trait-head::before { content: "▸ "; color: var(--faint); }
-.trait p { margin: 0.3rem 0 0; color: var(--muted); font-size: 0.9rem; }
 @media (max-width: 560px) {
-  .traits { grid-template-columns: 1fr; }
+  .trait { height: 15rem; }
 }
+.trait.active { display: block; animation: trait-in 0.35s ease; }
+@keyframes trait-in {
+  from { opacity: 0; transform: translateX(28px); }
+  to { opacity: 1; transform: none; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .trait.active { animation: none; }
+}
+.trait-head { color: var(--green); font-weight: 600; font-size: 1.2rem; }
+.trait-head::before { content: "▸ "; color: var(--faint); }
+.trait p { margin: 0.5rem 0 0; color: var(--fg); font-size: 1.05rem; line-height: 1.7; }
 
 /* ---- code blocks --------------------------------------------------- */
 
@@ -459,6 +499,25 @@ pre .copy {
   cursor: pointer;
 }
 pre .copy:hover { color: var(--fg); }
+
+/* use-it cheat sheet, like the sidebar's own `?` help */
+.keys-table {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.35rem 2rem;
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  padding: 0.8rem 1rem;
+  background: #121212;
+  margin: 1rem 0;
+}
+.keys-table > div { display: flex; align-items: baseline; gap: 1ch; }
+.keys-table .k { min-width: 12ch; flex: none; color: var(--fg); }
+.keys-table span:last-child { color: var(--muted); }
+.keys-table .dim { color: var(--faint); }
+@media (max-width: 560px) {
+  .keys-table { grid-template-columns: 1fr; }
+}
 
 kbd {
   font-family: var(--mono);

--- a/site/style.css
+++ b/site/style.css
@@ -1,0 +1,498 @@
+/* Palette lifted from src/sidebar.rs — the page wears the app's own colors. */
+:root {
+  --bg: #0e0e0e;
+  --bar-bg: #303030;            /* xterm 236, the focused title bar */
+  --fg: #c9c9c9;
+  --muted: #8a8a8a;
+  --faint: #5a5a5a;
+  --red: #e0665c;
+  --yellow: #d9b04c;
+  --green: #6cb56c;
+  --blocked-sel: rgb(42, 16, 16);
+  --blocked-bg: rgb(32, 12, 12);
+  --working-sel: rgb(38, 32, 16);
+  --working-bg: rgb(29, 24, 12);
+  --idle-sel: rgb(15, 36, 16);
+  --idle-bg: rgb(11, 27, 12);
+  --rule: #262626;
+  --term-bg: #101010;
+  --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+* { box-sizing: border-box; }
+
+html { scroll-behavior: smooth; }
+
+/* scroll reveal: sections drift up as they enter the viewport */
+.reveal {
+  opacity: 0;
+  transform: translateY(14px);
+  transition: opacity 0.45s ease, transform 0.45s ease;
+}
+.reveal.shown { opacity: 1; transform: none; }
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+  .reveal { opacity: 1; transform: none; transition: none; }
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--mono);
+  font-size: 15px;
+  line-height: 1.65;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c-red { color: var(--red); }
+.c-yellow { color: var(--yellow); }
+.c-green { color: var(--green); }
+.muted { color: var(--muted); }
+
+a { color: var(--green); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+/* ---- top nav, styled like a tmux status line ------------------------ */
+
+.topnav {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 1.2rem;
+  background: #1c1c1c;
+  border-bottom: 1px solid var(--rule);
+  padding: 0.25rem 1rem;
+  font-size: 0.85rem;
+  white-space: nowrap;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+.topnav::-webkit-scrollbar { display: none; }
+.topnav .brand { color: var(--green); font-weight: 600; }
+.topnav a { color: var(--muted); transition: color 0.15s, text-shadow 0.15s; }
+.topnav a:hover { color: var(--fg); text-decoration: none; }
+.topnav a.active {
+  color: var(--green);
+  text-shadow: 0 0 8px rgba(108, 181, 108, 0.9), 0 0 20px rgba(108, 181, 108, 0.45);
+}
+.topnav .ext { margin-left: auto; color: var(--green); }
+
+h2[id], #demo-section { scroll-margin-top: 3rem; }
+
+/* nav click: the target title flashes with a phosphor glow, then settles */
+@keyframes title-glow {
+  0% { color: var(--green); text-shadow: 0 0 12px rgba(108, 181, 108, 1), 0 0 32px rgba(108, 181, 108, 0.6); }
+  60% { color: var(--green); text-shadow: 0 0 8px rgba(108, 181, 108, 0.7), 0 0 20px rgba(108, 181, 108, 0.35); }
+  100% { color: var(--fg); text-shadow: none; }
+}
+h2.glance { animation: title-glow 1.1s ease-out; }
+@media (prefers-reduced-motion: reduce) {
+  h2.glance { animation: none; }
+}
+
+/* ---- hero ----------------------------------------------------------- */
+
+.hero {
+  max-width: 56rem;
+  margin: 0 auto;
+  padding: 4.5rem 1.25rem 1rem;
+  text-align: center;
+}
+
+h1 {
+  font-size: clamp(1.8rem, 5vw, 2.6rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0 0 0.8rem;
+}
+h1 .prompt { color: var(--green); }
+
+.tagline {
+  color: var(--muted);
+  font-size: clamp(0.95rem, 2.5vw, 1.1rem);
+  margin: 0 auto 1.2rem;
+  max-width: 40rem;
+}
+.tagline .c-red, .tagline .c-yellow, .tagline .c-green { font-weight: 600; }
+
+.badges {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.4rem 1.2rem;
+  margin: 0 0 2.5rem;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+.badges .sep { color: var(--faint); }
+#stars[hidden] { display: none; }
+
+.hero-install { margin: 2rem 0 0.4rem; font-size: 0.9rem; }
+.hero-pre {
+  max-width: 30rem;
+  margin: 0 auto 1rem;
+  text-align: left;
+}
+
+/* ---- terminal mockup ------------------------------------------------ */
+
+/* demo carousel tabs, styled like tmux window entries */
+.demo-tabs {
+  display: flex;
+  justify-content: center;
+  gap: 1.4rem;
+  margin-bottom: 0.7rem;
+}
+.demo-tab {
+  background: none;
+  border: none;
+  font: inherit;
+  font-size: 0.9rem;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 0.1rem 0.4rem;
+}
+.demo-tab:hover { color: var(--fg); }
+.demo-tab.active {
+  color: var(--green);
+  text-shadow: 0 0 8px rgba(108, 181, 108, 0.7);
+}
+.demo-tab.active::after { content: "*"; }
+
+.demo-caption {
+  color: var(--muted);
+  font-size: 0.85rem;
+  margin: 0.8rem 0 0;
+}
+
+/* Light terminal, matching the author's real setup: status bar on top with
+   a session pill and numbered window badges, blue ⤳ pane titles. */
+.term {
+  --t-fg: #c9c9c9;
+  --t-dim: #8a8a8a;
+  --t-blue: #6c8cd5;
+  --t-red: var(--red);
+  --t-yellow: var(--yellow);
+  --t-green: var(--green);
+  position: relative;
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  overflow: hidden;
+  text-align: left;
+  background: #101010;
+  color: var(--t-fg);
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+/* pressed-key hint, screencast style, bottom-right of the window */
+.key-osd {
+  position: absolute;
+  right: 1rem;
+  bottom: 0.8rem;
+  display: flex;
+  align-items: center;
+  gap: 0.8ch;
+  color: #9a9a9a;
+  font-size: 1.35rem;
+  pointer-events: none;
+}
+.key-osd .key {
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  border: 1px solid #4a4a4a;
+  border-bottom-width: 3px;
+  border-radius: 6px;
+  padding: 0.15rem 1.1ch;
+  font-weight: 700;
+  min-width: 2.2ch;
+  text-align: center;
+}
+.key-osd.pop { animation: key-pop 0.9s ease-out forwards; }
+@keyframes key-pop {
+  0% { opacity: 1; transform: scale(1.15); }
+  20% { transform: scale(1); }
+  70% { opacity: 1; }
+  100% { opacity: 0; }
+}
+
+.term-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  background: #1f1f1f;
+  border-bottom: 1px solid var(--rule);
+  padding: 0.45rem 0.7rem;
+}
+.term-bar .dot { width: 11px; height: 11px; border-radius: 50%; }
+.term-bar .d1 { background: #ff5f57; }
+.term-bar .d2 { background: #febc2e; }
+.term-bar .d3 { background: #28c840; }
+.term-title {
+  flex: 1;
+  text-align: center;
+  color: var(--faint);
+  font-size: 0.8rem;
+  margin-right: 2.9rem;  /* offset the dots so the title truly centers */
+}
+
+.term-top {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  background: #161616;
+  color: #b8b8b8;
+  padding: 0.3rem 0.6rem;
+  font-size: 0.85rem;
+  white-space: nowrap;
+  overflow: hidden;
+}
+.term-top .pill {
+  background: #000;
+  color: #eee;
+  border-radius: 999px;
+  padding: 0 0.9ch;
+}
+.term-top .badge {
+  display: inline-block;
+  width: 1.55em;
+  border-radius: 50%;
+  text-align: center;
+  color: #1a1a1a;
+  font-size: 0.9em;
+}
+.term-top .b1 { background: #a8c7fa; }
+.term-top .b2 { background: #e7c9a9; }
+.term-top .b3 { background: #a9d7b3; }
+.term-top .b4 { background: #f2b8c6; }
+.term-top .wins { display: inline-flex; gap: 1rem; }
+.term-top .win.active { color: #fff; font-weight: 700; }
+.term-top .clock-wrap { margin-left: auto; color: #8a8a8a; }
+
+.term-body { display: flex; min-height: 19rem; }
+
+.pane-title { color: var(--t-blue); padding: 0.1rem 0.6rem; }
+
+/* the main "pane" next to the sidebar */
+.pane-wrap {
+  flex: 1;
+  min-width: 0;
+  border-left: 1px solid var(--rule);
+}
+.pane {
+  padding: 0.2rem 0.9rem 0.5rem;
+  text-align: left;
+  white-space: pre-wrap;
+  overflow: hidden;
+}
+.pane .l-dim { color: var(--t-dim); }
+.pane .l-yellow { color: var(--t-yellow); }
+.pane .l-green { color: var(--t-green); }
+.pane .l-box { color: var(--t-fg); background: #1c1c1c; }
+
+/* ---- sidebar (the real thing, in CSS) ------------------------------- */
+
+.sidebar {
+  width: 32ch;
+  max-width: 55%;
+  flex: none;
+}
+
+.sidebar .bar {
+  color: var(--t-green);
+  font-weight: 700;
+  padding: 0 0.6rem;
+}
+
+.sidebar .bar .bar-filter { color: var(--t-dim); font-weight: 400; }
+.sidebar .hint {
+  color: var(--t-dim);
+  padding: 0.05rem 0.6rem;
+}
+
+.sidebar .session {
+  color: var(--t-blue);         /* bold blue session headers */
+  font-weight: 700;
+  padding: 0.1rem 0.6rem;
+}
+
+.agent, .entry .title {
+  display: flex;
+  gap: 0.55ch;
+  padding: 0.05rem 0.6rem;
+  white-space: nowrap;
+  overflow: hidden;
+}
+/* cursor color follows the row state, like cursor_mark() */
+.agent .cursor { color: var(--t-green); visibility: hidden; width: 1ch; flex: none; font-weight: 700; }
+.entry.selected .cursor { visibility: visible; }
+.entry[data-state="blocked"] .cursor { color: var(--t-red); }
+.entry[data-state="working"] .cursor { color: var(--t-yellow); }
+.agent .name { flex: none; font-weight: 700; }
+.agent .rest {
+  color: var(--t-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.entry .title {
+  color: var(--t-dim);
+  padding-left: calc(0.6rem + 4.1ch);   /* 5-space indent under the agent name */
+}
+
+/* Only the selected row is tinted, exactly like state_bg() — the app paints
+   its fixed dark row colors even on a light terminal, so the selected entry
+   flips to light-on-dark, matching the real screenshot. */
+.entry.selected { color: #e8e8e8; }
+.entry.selected .cursor { color: #e8e8e8; }
+.entry.selected .rest, .entry.selected .title { color: #a8a8a8; }
+.entry.selected[data-state="blocked"] { background: var(--blocked-sel); }
+.entry.selected[data-state="working"] { background: var(--working-sel); }
+.entry.selected[data-state="idle"],
+.entry.selected[data-state="done"] { background: var(--idle-sel); }
+
+.entry[data-state="blocked"] .glyph { color: var(--t-red); animation: blink 1s steps(1) infinite; }
+.entry[data-state="working"] .glyph { color: var(--t-yellow); }
+.entry[data-state="idle"] .glyph, .entry[data-state="done"] .glyph { color: var(--t-green); }
+.entry[data-state="done"] .glyph { animation: blink 1s steps(1) infinite; }
+.entry.selected .glyph { color: #7ddb84; }
+.entry.selected[data-state="blocked"] .glyph { color: #ff8a7a; }
+.entry.selected[data-state="working"] .glyph { color: #e8c15a; }
+
+@keyframes blink { 50% { opacity: 0; } }
+
+@media (prefers-reduced-motion: reduce) {
+  .glyph { animation: none !important; }
+}
+
+/* ---- main column ----------------------------------------------------- */
+
+main {
+  max-width: 46rem;
+  margin: 0 auto;
+  padding: 1rem 1.25rem 4rem;
+}
+
+h2 {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--fg);
+  margin: 3rem 0 0.8rem;
+}
+h2::before { content: "## "; color: var(--faint); }
+
+p { margin: 0.7rem 0; }
+
+/* ---- states legend ------------------------------------------------ */
+
+.states { border: 1px solid var(--rule); border-radius: 4px; overflow: hidden; margin: 1rem 0; }
+.states .row { display: flex; gap: 1ch; padding: 0.25rem 0.75rem; }
+.states .row .glyph { width: 2ch; flex: none; }
+.states .row b { font-weight: 600; }
+.states .row[data-state="blocked"] { background: var(--blocked-bg); }
+.states .row[data-state="blocked"] .glyph { color: var(--red); animation: blink 1s steps(1) infinite; }
+.states .row[data-state="working"] { background: var(--working-bg); }
+.states .row[data-state="working"] .glyph { color: var(--yellow); }
+.states .row[data-state="done"] { background: var(--idle-bg); }
+.states .row[data-state="done"] .glyph { color: var(--green); animation: blink 1s steps(1) infinite; }
+.states .row[data-state="idle"] { background: var(--idle-bg); }
+.states .row[data-state="idle"] .glyph { color: var(--green); }
+
+/* ---- trait grid ----------------------------------------------------- */
+
+.traits {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.8rem;
+  margin: 1rem 0;
+}
+.trait {
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  padding: 0.6rem 0.9rem;
+  background: #121212;
+}
+.trait-head { color: var(--green); font-weight: 600; }
+.trait-head::before { content: "▸ "; color: var(--faint); }
+.trait p { margin: 0.3rem 0 0; color: var(--muted); font-size: 0.9rem; }
+@media (max-width: 560px) {
+  .traits { grid-template-columns: 1fr; }
+}
+
+/* ---- code blocks --------------------------------------------------- */
+
+pre {
+  position: relative;
+  background: #161616;
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  padding: 0.7rem 3.2rem 0.7rem 0.9rem;
+  overflow-x: auto;
+  font-size: 0.88rem;
+  line-height: 1.55;
+  scrollbar-color: var(--bar-bg) #161616;
+  scrollbar-width: thin;
+}
+code { font-family: var(--mono); }
+p code, li code {
+  background: #1c1c1c;
+  border: 1px solid var(--rule);
+  border-radius: 3px;
+  padding: 0 0.3ch;
+  font-size: 0.9em;
+}
+
+pre .copy {
+  position: absolute;
+  top: 0.4rem;
+  right: 0.4rem;
+  background: var(--bar-bg);
+  color: var(--muted);
+  border: none;
+  border-radius: 3px;
+  font: inherit;
+  font-size: 0.8rem;
+  padding: 0.05rem 0.6ch;
+  cursor: pointer;
+}
+pre .copy:hover { color: var(--fg); }
+
+kbd {
+  font-family: var(--mono);
+  background: #1c1c1c;
+  border: 1px solid #3a3a3a;
+  border-bottom-width: 2px;
+  border-radius: 3px;
+  padding: 0 0.5ch;
+  font-size: 0.85em;
+}
+
+ul { padding-left: 1.4rem; margin: 0.7rem 0; }
+li { margin: 0.25rem 0; }
+li::marker { color: var(--faint); }
+
+/* ---- latest release ------------------------------------------------ */
+
+#release-head { display: flex; gap: 1.2ch; flex-wrap: wrap; align-items: baseline; }
+#release-tag { color: var(--green); font-weight: 600; }
+#release-date { color: var(--muted); font-size: 0.85rem; }
+#release-notes { white-space: pre-wrap; }
+#release-notes[hidden] { display: none; }
+
+footer {
+  margin-top: 3.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--rule);
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+@media (max-width: 480px) {
+  body { font-size: 14px; }
+  .hero { padding-top: 2.5rem; }
+  .pane-wrap { display: none; }   /* sidebar alone fits a phone */
+  .sidebar { width: 100%; max-width: none; }
+}


### PR DESCRIPTION
Static landing page under `site/` plus a `pages.yml` deploy workflow.

- Terminal-styled page matching the app's real sidebar palette and layout
- Animated tmux mock: monitor + search demo carousel, key-press hints, per-session status bar
- Live GitHub data (stars, latest release + notes) fetched client-side with static fallbacks
- Deploys `site/` via actions/deploy-pages on pushes to master touching site files

After merge (one-time): enable Pages with source "GitHub Actions" — Settings → Pages, or
`gh api -X POST repos/snirt/tmux-agents-mon/pages -f build_type=workflow`.
Site will be at https://snirt.github.io/tmux-agents-mon/