### PR TITLE
ci: skip builds for documentation-only changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,15 @@ on:
   push:
     branches: [master]
     tags: ['v*']
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'site/**'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'site/**'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- skip Build and Release for Markdown-only, docs, and site changes
- preserve tag and manual workflow runs
- leave site deployment to its existing path-filtered workflow

## Verification
- YAML language server: clean
- `git diff --check`