### PR TITLE
ci: satisfy required checks on docs-only PRs

### DIFF
--- a/.github/workflows/docs-skip.yml
+++ b/.github/workflows/docs-skip.yml
@@ -1,0 +1,38 @@
+name: Docs-only checks
+
+# build.yml ignores these paths, but master's branch protection still
+# requires its check contexts. This no-op twin reports the same context
+# names as instant successes so docs/site-only PRs can merge.
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+      - 'docs/**'
+      - 'site/**'
+
+permissions:
+  contents: read
+
+jobs:
+  version:
+    name: Validate version
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only change, skipped"
+  sanity:
+    name: Real tmux sanity
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only change, skipped"
+  build:
+    name: ${{ matrix.artifact }}
+    strategy:
+      matrix:
+        artifact:
+          - tmux-agents-mon-linux-x86_64
+          - tmux-agents-mon-linux-aarch64
+          - tmux-agents-mon-macos-x86_64
+          - tmux-agents-mon-macos-aarch64
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only change, skipped"


### PR DESCRIPTION
PR #33's `paths-ignore` means docs/site-only PRs never run build.yml, but master's protection requires its six contexts — so #31/#34 hang on "Expected" checks. This adds the standard no-op twin workflow: same job names, triggered only on the ignored paths, instant success. Mixed PRs run the real workflow as before.