### PR TITLE
Release Agenmux v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agenmux"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "libc",
  "mac-usernotifications",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agenmux"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,18 +1,17 @@
-# Agenmux v0.2.1
+# Agenmux v0.3.0
 
 ## What's changed
 
-### Fixes
+### Agenmux rebrand
 
-- Improved Claude working-state detection for live activity lines ([#14](https://github.com/snirt/agenmux/pull/14)).
-- Fixed concurrent macOS notifications with a shared broker ([#18](https://github.com/snirt/agenmux/pull/18)).
-- Improved notification authorization, click handling, retries, and shutdown behavior.
+- Renamed the runtime, binaries, tmux options, configuration path, release artifacts, and documentation to Agenmux ([#37](https://github.com/snirt/agenmux/pull/37)).
+- Preserved `agents-mon` entrypoints, options, environment variables, config paths, package launchers, and release state as compatibility inputs for one release cycle.
+- Renamed the macOS notification helper to `Agenmux.app` with bundle ID `io.github.snirt.agenmux`.
 
-### Release tooling
+### Developer workflow
 
-- Added safer version bump and release scripts.
-- Added release-process tests and stronger tmux sanity checks.
-- Updated version to `0.2.1` ([#19](https://github.com/snirt/agenmux/pull/19)).
+- Added `make dev-use` and `make dev-stop` for switching the active tmux server between local debug and release binaries.
+- Added debug build timestamps to sidebar titles while keeping release titles versioned.
 
 ### Assets
 
@@ -22,4 +21,4 @@
 - macOS aarch64
 - SHA-256 checksums
 
-**Full changelog:** <https://github.com/snirt/agenmux/compare/v0.2.0...v0.2.1>
+**Full changelog:** <https://github.com/snirt/agenmux/compare/v0.2.1...v0.3.0>


### PR DESCRIPTION
## Summary
- bump Agenmux from v0.2.1 to v0.3.0
- publish release notes for the Agenmux rebrand and developer workflow additions

## Verification
- `mise exec rust@latest -- cargo test`
- `AGENMUX_BIN=target/debug/agenmux ./tests/run.sh`
- `git diff --check`