### PR TITLE
docs: lowercase agenmux brand name

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -33,7 +33,7 @@ body:
     id: environment
     attributes:
       label: Environment
-      description: Include Agenmux version, OS, tmux version, and agent type.
+      description: Include agenmux version, OS, tmux version, and agent type.
     validations:
       required: true
   - type: textarea

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Agenmux
+# agenmux
 
 [![agenmux logo](site/logo.png)](https://snirt.github.io/agenmux/)
 
 Website: <https://snirt.github.io/agenmux/>
 
-**Rebranding note:** `agents-mon` is now **Agenmux**. Existing installations
+**Rebranding note:** `agents-mon` is now **agenmux**. Existing installations
 remain compatible for one release cycle; see [Upgrading from agents-mon](#upgrading-from-agents-mon).
 
 Monitor AI coding agents running in your tmux panes. A sidebar and a status-line
@@ -56,7 +56,7 @@ required build step on a supported release platform.
 Existing installs continue working for one release cycle. `agents-mon.tmux`,
 `@agents-mon-*`, `#{agents_mon}`, `AGENTS_MON_*`, and
 `~/.config/tmux-agents-mon/agents/` are accepted as compatibility inputs;
-Agenmux writes only canonical names. Canonical values win when both exist.
+agenmux writes only canonical names. Canonical values win when both exist.
 
 | Legacy | Canonical |
 | --- | --- |
@@ -207,8 +207,8 @@ On macOS, agenmux sends notifications natively through
 Homebrew or other runtime dependency, and no setup: installing or updating
 the plugin automatically places a signed, background-only `Agenmux.app`
 into `~/Applications` (skipped while `@agenmux-notifications` is off).
-macOS asks for permission with the first notification; allow **Agenmux**
-when prompted, or later under System Settings → Notifications → Agenmux.
+macOS asks for permission with the first notification; allow **agenmux**
+when prompted, or later under System Settings → Notifications → agenmux.
 Denying keeps notifications fully silent — there is no fallback around your
 choice. Plugin updates refresh the app automatically and the permission
 survives.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,10 @@
-# Agenmux v0.3.0
+# agenmux v0.3.0
 
 ## What's changed
 
-### Agenmux rebrand
+### agenmux rebrand
 
-- Renamed the runtime, binaries, tmux options, configuration path, release artifacts, and documentation to Agenmux ([#37](https://github.com/snirt/agenmux/pull/37)).
+- Renamed the runtime, binaries, tmux options, configuration path, release artifacts, and documentation to agenmux ([#37](https://github.com/snirt/agenmux/pull/37)).
 - Preserved `agents-mon` entrypoints, options, environment variables, config paths, package launchers, and release state as compatibility inputs for one release cycle.
 - Renamed the macOS notification helper to `Agenmux.app` with bundle ID `io.github.snirt.agenmux`.
 

--- a/agents-mon.tmux
+++ b/agents-mon.tmux
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-# Compatibility entrypoint for pre-Agenmux tmux configurations.
+# Compatibility entrypoint for pre-agenmux tmux configurations.
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 exec bash "$DIR/agenmux.tmux" "$@"

--- a/scripts/install-app.sh
+++ b/scripts/install-app.sh
@@ -48,9 +48,9 @@ cat >"$stage/Contents/Info.plist" <<PLIST
 	<key>CFBundleIdentifier</key>
 	<string>io.github.snirt.agenmux</string>
 	<key>CFBundleName</key>
-	<string>Agenmux</string>
+	<string>agenmux</string>
 	<key>CFBundleDisplayName</key>
-	<string>Agenmux</string>
+	<string>agenmux</string>
 	<key>CFBundleExecutable</key>
 	<string>agenmux-notifier</string>
 	<key>CFBundlePackageType</key>
@@ -83,5 +83,5 @@ echo "installed $app"
 if "$app/Contents/MacOS/agenmux-notifier" --setup; then
 	echo "✓ notifications enabled"
 else
-	echo "Notifications are off. Enable: System Settings → Notifications → Agenmux."
+	echo "Notifications are off. Enable: System Settings → Notifications → agenmux."
 fi

--- a/site/index.html
+++ b/site/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Agenmux — monitor AI coding agents in tmux</title>
+    <title>agenmux — monitor AI coding agents in tmux</title>
     <meta
       name="description"
       content="Monitor AI coding agents (Claude Code, Codex, OpenCode, Pi…) in your tmux panes — sidebar + status-line segment. No hooks, nothing runs inside your agents."
@@ -13,7 +13,7 @@
   <body>
     <nav class="topnav">
       <a class="brand" href="#" aria-label="back to top"
-        ><img class="brand-logo" src="logo.png" alt="Agenmux"
+        ><img class="brand-logo" src="logo.png" alt="agenmux"
       /></a>
       <a href="#demo-section">demo</a>
       <a href="#how">how</a>

--- a/src/bin/agenmux-notifier.rs
+++ b/src/bin/agenmux-notifier.rs
@@ -76,7 +76,7 @@ fn setup() -> i32 {
         Ok(false) | Err(_) => return 4,
     }
     match noti::Notification::new()
-        .title("Agenmux")
+        .title("agenmux")
         .message("Notifications are ready.")
         .sound(noti::sound::GLASS)
         .send_blocking()

--- a/src/bin/agenmux-notifier/broker.rs
+++ b/src/bin/agenmux-notifier/broker.rs
@@ -698,7 +698,7 @@ mod tests {
     #[test]
     fn request_round_trip_preserves_missing_click() {
         let expected = NotificationRequest {
-            title: "Agenmux".into(),
+            title: "agenmux".into(),
             body: "ready".into(),
             click: None,
         };


### PR DESCRIPTION
Lowercase `Agenmux` → `agenmux` across README, release notes, landing page, bug issue template, compat entrypoint comment, notification title, and the helper's plist display name.

Unchanged on purpose: `Agenmux.app` bundle path and bundle ID `io.github.snirt.agenmux`, so existing installs and notification permission keep working.

Tests: `cargo test` and `tests/run.sh` green.