### PR TITLE
fix: survive TMPDIR mismatch and refuse malformed TMUX in toggle

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -27,7 +27,7 @@ pub fn click(pane: &str, y: usize, client: &str) -> i32 {
     let target = y
         .checked_sub(1)
         .and_then(|line| {
-            std::fs::read_to_string(std::env::temp_dir().join("agenmux-rows"))
+            std::fs::read_to_string(tmux::runtime_dir().join("agenmux-rows"))
                 .ok()?
                 .lines()
                 .nth(line)

--- a/src/panes.rs
+++ b/src/panes.rs
@@ -275,6 +275,7 @@ pub fn teardown() -> i32 {
     }
     let _ = tmux::command_status(&["set-option", "-gu", "@agenmux-on"]);
     let _ = tmux::command_status(&["set-option", "-gu", "@agenmux-control-client"]);
+    let _ = tmux::command_status(&["set-option", "-gu", "@agenmux-runtime-dir"]);
     let _ = tmux::command_status(&["set-option", "-gu", "@agents-mon-on"]);
     let _ = tmux::command_status(&["set-option", "-gu", "@agents-mon-control-client"]);
     0

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -362,7 +362,7 @@ pub fn send_key(name: &str) -> i32 {
             _ => return 2,
         }
     };
-    let path = std::env::temp_dir().join("agenmux-keys");
+    let path = crate::tmux::runtime_dir().join("agenmux-keys");
     let Ok(c) = std::ffi::CString::new(path.as_os_str().as_encoded_bytes()) else {
         return 1;
     };
@@ -794,6 +794,10 @@ pub fn run_daemon(plugin_dir: PathBuf, cache_file: PathBuf) -> i32 {
         }
         std::thread::sleep(Duration::from_millis(10));
     }
+    let quoted_tmp = tmp.to_string_lossy().replace('\'', "\\'");
+    let _ = sb.tmux.run(&format!(
+        "set-option -g @agenmux-runtime-dir '{quoted_tmp}'"
+    ));
     sb.daemon = Some(Daemon {
         keys_path,
         keys_fd,
@@ -861,6 +865,9 @@ fn event_loop(sb: &mut Sidebar) -> bool {
             }
             if sb.daemon.is_some() && !sb.mirror_tick() {
                 break; // all preserved panes gone — nothing left to display
+            }
+            if sb.daemon.as_ref().is_some_and(|d| !d.keys_path.exists()) {
+                break; // runtime dir vanished: deaf to keys, better gone than a zombie
             }
             sb.render(false);
             // a scan takes tens of ms — with the pre-scan `now`, a tick due

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -2,6 +2,7 @@
 // responses out. Replaces one fork per tmux command with a write+read.
 use std::io::{BufRead, BufReader, Write};
 use std::os::unix::io::AsRawFd;
+use std::path::PathBuf;
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 
 pub enum TmuxError {
@@ -38,6 +39,18 @@ pub fn command(args: &[&str]) -> Result<String, TmuxError> {
         ));
     }
     String::from_utf8(output.stdout).map_err(|e| TmuxError::Error(e.to_string()))
+}
+
+/// Where the daemon keeps its key FIFO and row map. The daemon publishes its
+/// own temp dir as @agenmux-runtime-dir so key/click/wheel senders find it even
+/// when tmux spawns them with a different TMPDIR than the daemon inherited.
+pub fn runtime_dir() -> PathBuf {
+    command(&["show-option", "-gqv", "@agenmux-runtime-dir"])
+        .ok()
+        .map(|dir| dir.trim_end().to_string())
+        .filter(|dir| !dir.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(std::env::temp_dir)
 }
 
 pub fn command_status(args: &[&str]) -> Result<(), TmuxError> {

--- a/src/toggle.rs
+++ b/src/toggle.rs
@@ -4,6 +4,17 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 pub fn run(plugin_dir: &Path, requested_mode: Option<&str>, requested_client: Option<&str>) -> i32 {
+    // tmux ignores a TMUX value that names no socket and silently falls back to
+    // the default server. A repro script with an empty socket variable must not
+    // tear down and re-own the user's live sidebar.
+    if let Ok(env) = std::env::var("TMUX") {
+        if !env.is_empty() && !env.starts_with('/') {
+            eprintln!(
+                "agenmux: TMUX={env:?} names no socket; refusing to touch the default server"
+            );
+            return 1;
+        }
+    }
     let mode = requested_mode
         .filter(|mode| !mode.is_empty())
         .map(str::to_string)
@@ -58,6 +69,9 @@ fn control_alive() -> bool {
     !control.is_empty()
         && tmux::lines(&["list-clients", "-F", "#{client_name}"])
             .is_ok_and(|clients| clients.iter().any(|client| client == &control))
+        // control client up but FIFO gone = deaf daemon; treat as dead so the
+        // caller tears down and starts fresh instead of re-selecting a zombie
+        && tmux::runtime_dir().join("agenmux-keys").exists()
 }
 
 fn split(plugin_dir: &Path, client: Option<String>) -> i32 {

--- a/tests/daemon-orphan.sh
+++ b/tests/daemon-orphan.sh
@@ -53,7 +53,9 @@ sleep 4
 survives_when_current=0
 kill -0 "$daemon" 2>/dev/null && survives_when_current=1
 
-env TMPDIR="$tmp" TMUX="$sock,$server_pid,0" "$BIN" key versions || {
+# Senders spawned by tmux need not share the daemon's TMPDIR: the daemon
+# publishes its runtime dir, so a foreign TMPDIR here must still deliver.
+env TMPDIR="$tmp/not-the-daemons" TMUX="$sock,$server_pid,0" "$BIN" key versions || {
   echo "FAIL daemon-orphan-exits: could not open version picker"
   exit 1
 }
@@ -86,5 +88,40 @@ if [ "$survives_when_current" -eq 1 ] && [ "$exits_when_replaced" -eq 1 ]; then
   echo "ok   daemon-orphan-exits"
 else
   echo "FAIL daemon-orphan-exits: survives-while-current=$survives_when_current exits-when-replaced=$exits_when_replaced"
+  exit 1
+fi
+
+# A daemon whose runtime dir was deleted under it can never hear a key again.
+# It must exit with teardown so the next toggle starts fresh instead of
+# re-selecting a zombie sidebar.
+before="$(pgrep -f 'agenmux daemon' 2>/dev/null | sort)"
+env TMPDIR="$tmp" TMUX="$sock,$server_pid,0" AGENMUX_DIR="$DIR" \
+  "$BIN" toggle split
+daemon=''
+for _ in $(seq 1 60); do
+  after="$(pgrep -f 'agenmux daemon' 2>/dev/null | sort)"
+  daemon="$(comm -13 <(printf '%s\n' "$before") <(printf '%s\n' "$after") | head -n 1)"
+  [ -n "$daemon" ] && break
+  sleep 0.1
+done
+[ -n "$daemon" ] && [ -p "$tmp/agenmux-keys" ] || {
+  echo "FAIL daemon-exits-without-runtime-dir: no daemon or FIFO after restart"
+  exit 1
+}
+rm -f "$tmp/agenmux-keys"
+exits_without_fifo=0
+for _ in $(seq 1 40); do
+  kill -0 "$daemon" 2>/dev/null || {
+    exits_without_fifo=1
+    break
+  }
+  sleep 0.2
+done
+if [ "$exits_without_fifo" -eq 1 ] &&
+  [ -z "$(tmux -S "$sock" show-option -gqv @agenmux-on)" ] &&
+  [ -z "$(tmux -S "$sock" show-option -gqv @agenmux-runtime-dir)" ]; then
+  echo "ok   daemon-exits-without-runtime-dir"
+else
+  echo "FAIL daemon-exits-without-runtime-dir: exited=$exits_without_fifo on=$(tmux -S "$sock" show-option -gqv @agenmux-on)"
   exit 1
 fi

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -553,6 +553,26 @@ SH
   fi
   rm -rf "$tmp"
 fi
+if [ "$fail" -eq 0 ]; then
+  # TMUX set but naming no socket: tmux would fall back to the default server.
+  # toggle must refuse before it issues a single tmux command.
+  tmp="$(mktemp -d)"
+  mkdir -p "$tmp/bin"
+  printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$*" >> "$TMUX_STUB_LOG"\nexit 0\n' >"$tmp/bin/tmux"
+  chmod +x "$tmp/bin/tmux"
+  : >"$tmp/tmux.log"
+  TMUX=',,0' TMUX_STUB_LOG="$tmp/tmux.log" PATH="$tmp/bin:$PATH" \
+    "$BIN" toggle split 2>/dev/null
+  rc=$?
+  if [ "$rc" -eq 1 ] && [ ! -s "$tmp/tmux.log" ]; then
+    echo "ok   toggle-refuses-malformed-tmux-env"
+  else
+    echo "FAIL toggle-refuses-malformed-tmux-env: rc=$rc"
+    cat "$tmp/tmux.log"
+    fail=1
+  fi
+  rm -rf "$tmp"
+fi
 if [ "$fail" -eq 0 ] && command -v tmux >/dev/null && [ -x "$BIN" ]; then
   # mirror mode end to end: toggle puts a mirror pane in every window, window
   # switches change NO layout (the whole point — no reflow bump), new windows


### PR DESCRIPTION
## Problem

The daemon and its `key`/`click`/`wheel` senders each resolved `$TMPDIR/agenmux-keys` from their own environment and assumed they matched. A `toggle` launched with a foreign `TMPDIR` (a repro script's `mktemp -d`, deleted afterwards) left a daemon nobody could reach: keys opened a FIFO that did not exist, prefix+E hit the "reuse" path and only re-selected the pane, and the sidebar could not be closed. Same script also had `TMUX=",,0"`, which tmux silently routes to the default server, so the repro re-owned the live sidebar.

## Fix

- Daemon publishes its runtime dir as `@agenmux-runtime-dir`; senders read it, falling back to their own `TMPDIR`. Unset on teardown.
- `toggle` treats a live control client with no key FIFO as dead → existing teardown + fresh daemon path. Prefix+E now heals a zombie.
- Daemon exits with teardown when its FIFO vanishes.
- `toggle` refuses a non-empty `TMUX` that does not start with `/` before issuing any tmux command.

## Tests

- `toggle-refuses-malformed-tmux-env` (run.sh, stub tmux, asserts zero tmux calls)
- `daemon-orphan-exits` now sends its key with a foreign `TMPDIR`
- `daemon-exits-without-runtime-dir` (daemon-orphan.sh): delete FIFO under a live daemon → exits, options unset

Verified live against a real zombie daemon: prefix+E replaced it, `Q` closed everything, reopen healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCbp8jpD4hDCUCM3NS562E