### PR TITLE
Fix restored sidebar ghost panes

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,9 @@ run.
 
 ## Known limits
 
+- After a tmux server restart through a session-restore tool, restored sidebar
+  panes may return as idle shells. Press `prefix+A` to remove them and reopen
+  the sidebar. The original per-window layout cannot be recovered.
 - State is inferred from what's on screen; transient redraws can flicker
   (the sidebar debounces transitions to idle by one tick).
 - Pane titles are only used when the agent's OSC title escapes reach tmux.

--- a/src/panes.rs
+++ b/src/panes.rs
@@ -1,6 +1,8 @@
 use crate::tmux::{self, TmuxError};
 use std::process::{Command, Stdio};
 
+pub const IS_SIDEBAR: &str = "#{||:#{==:#{pane_title},agenmux},#{==:#{@agenmux},1}}";
+
 struct TmuxLock(String);
 
 impl TmuxLock {
@@ -40,6 +42,73 @@ fn newest_value(rows: &[String]) -> Option<String> {
         .map(|(_, value)| value)
 }
 
+// Restore tools respawn processless sidebar panes as idle shells; remove them before splitting.
+fn kill_ghosts(win: &str, width: &str) {
+    let default_shell =
+        tmux::command(&["show-option", "-gqv", "default-shell"]).unwrap_or_default();
+    let default_shell = default_shell.trim().rsplit('/').next().unwrap_or_default();
+    let snapshot = crate::procs::Snapshot::take();
+    let panes = tmux::lines(&[
+        "list-panes",
+        "-t",
+        win,
+        "-F",
+        "#{pane_id}\t#{pane_left}\t#{pane_top}\t#{pane_width}\t#{pane_height}\t#{window_height}\t#{window_panes}\t#{pane_pid}\t#{pane_current_command}\t#{pane_title}",
+    ])
+    .unwrap_or_default();
+    for row in panes {
+        let mut fields = row.split('\t');
+        let (
+            Some(pane),
+            Some("0"),
+            Some("0"),
+            Some(pane_width),
+            Some(pane_height),
+            Some(window_height),
+            Some(window_panes),
+            Some(pid),
+            Some(command),
+            Some(title),
+        ) = (
+            fields.next(),
+            fields.next(),
+            fields.next(),
+            fields.next(),
+            fields.next(),
+            fields.next(),
+            fields.next(),
+            fields.next(),
+            fields.next(),
+            fields.next(),
+        )
+        else {
+            continue;
+        };
+        let command = command
+            .trim_start_matches('-')
+            .rsplit('/')
+            .next()
+            .unwrap_or(command);
+        let is_shell = matches!(
+            command,
+            "sh" | "bash" | "zsh" | "fish" | "nu" | "dash" | "ksh" | "tcsh" | "csh"
+        ) || (!default_shell.is_empty() && command == default_shell);
+        let (Ok(pid), Ok(window_panes)) = (pid.parse::<u32>(), window_panes.parse::<u32>()) else {
+            continue;
+        };
+        if window_panes > 1
+            && pane_width == width
+            && pane_height == window_height
+            && pid != 0
+            && title != "agenmux"
+            && is_shell
+            && !snapshot.has_children(pid)
+        {
+            let _ = tmux::command_status(&["kill-pane", "-t", pane]);
+        }
+    }
+}
+
 pub fn pane_add(window: Option<&str>) -> i32 {
     if !tmux::command(&["show-option", "-gqv", "@agenmux-on"])
         .is_ok_and(|value| value.trim() == "1")
@@ -68,8 +137,16 @@ pub fn pane_add(window: Option<&str>) -> i32 {
     {
         return 0;
     }
-    if tmux::lines(&["list-panes", "-t", &win, "-F", "#{pane_title}"])
-        .is_ok_and(|titles| titles.iter().any(|title| title == "agenmux"))
+    if tmux::lines(&[
+        "list-panes",
+        "-t",
+        &win,
+        "-f",
+        IS_SIDEBAR,
+        "-F",
+        "#{pane_id}",
+    ])
+    .is_ok_and(|panes| !panes.is_empty())
     {
         return 0;
     }
@@ -79,6 +156,7 @@ pub fn pane_add(window: Option<&str>) -> i32 {
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| "30".to_string());
+    kill_ghosts(&win, &width);
     let layout = match tmux::command(&["display-message", "-p", "-t", &win, "#{window_layout}"]) {
         Ok(layout) => layout.trim_end().to_string(),
         Err(_) => return 1,
@@ -118,6 +196,7 @@ pub fn pane_add(window: Option<&str>) -> i32 {
         return 1;
     }
     let _ = tmux::command_status(&["set-option", "-p", "-t", &pane, "allow-rename", "off"]);
+    let _ = tmux::command_status(&["set-option", "-p", "-t", &pane, "@agenmux", "1"]);
     let _ = tmux::command_status(&["select-pane", "-t", &pane, "-T", "agenmux"]);
     0
 }
@@ -128,13 +207,10 @@ pub fn pane_pin() -> i32 {
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| "30".to_string());
-    let panes =
-        tmux::lines(&["list-panes", "-a", "-F", "#{pane_id}\t#{pane_title}"]).unwrap_or_default();
-    for row in panes {
-        let Some((pane, "agenmux")) = row.split_once('\t') else {
-            continue;
-        };
-        let _ = tmux::command_status(&["resize-pane", "-t", pane, "-x", &width]);
+    let panes = tmux::lines(&["list-panes", "-a", "-f", IS_SIDEBAR, "-F", "#{pane_id}"])
+        .unwrap_or_default();
+    for pane in panes {
+        let _ = tmux::command_status(&["resize-pane", "-t", &pane, "-x", &width]);
     }
     0
 }
@@ -158,9 +234,17 @@ pub fn pane_orphan() -> i32 {
         else {
             continue;
         };
-        let title =
-            tmux::command(&["list-panes", "-t", win, "-F", "#{pane_title}"]).unwrap_or_default();
-        if title.trim() != "agenmux" {
+        if !tmux::lines(&[
+            "list-panes",
+            "-t",
+            win,
+            "-f",
+            IS_SIDEBAR,
+            "-F",
+            "#{pane_id}",
+        ])
+        .is_ok_and(|panes| !panes.is_empty())
+        {
             continue;
         }
 
@@ -240,22 +324,20 @@ fn restore_layout(window: &str) {
 }
 
 pub fn teardown() -> i32 {
+    let sidebar_filter = ["#{||:", IS_SIDEBAR, ",#{==:#{pane_title},agents-mon}}"].concat();
     let panes = tmux::lines(&[
         "list-panes",
         "-a",
+        "-f",
+        &sidebar_filter,
         "-F",
-        "#{pane_id}\t#{pane_title}\t#{window_id}",
+        "#{pane_id}\t#{window_id}",
     ])
     .unwrap_or_default();
     for row in panes {
-        let mut fields = row.split('\t');
-        let (Some(pane), Some(title), Some(window)) = (fields.next(), fields.next(), fields.next())
-        else {
+        let Some((pane, window)) = row.split_once('\t') else {
             continue;
         };
-        if !matches!(title, "agenmux" | "agents-mon") {
-            continue;
-        }
         let _ = tmux::command_status(&["kill-pane", "-t", pane]);
         restore_layout(window);
     }

--- a/src/procs.rs
+++ b/src/procs.rs
@@ -32,6 +32,12 @@ impl Snapshot {
         Snapshot { sys, children }
     }
 
+    pub fn has_children(&self, pid: u32) -> bool {
+        self.children
+            .get(&pid)
+            .is_some_and(|children| !children.is_empty())
+    }
+
     /// BFS over the pane's process tree, root included (agent may be the
     /// pane command itself); argv fetched for just this subtree.
     fn descendant_argvs(&mut self, root: u32) -> Vec<Vec<String>> {

--- a/src/toggle.rs
+++ b/src/toggle.rs
@@ -112,8 +112,16 @@ fn split(plugin_dir: &Path, client: Option<String>) -> i32 {
 }
 
 fn window_has_sidebar(window: &str) -> bool {
-    tmux::lines(&["list-panes", "-t", window, "-F", "#{pane_title}"])
-        .is_ok_and(|titles| titles.iter().any(|title| title == "agenmux"))
+    tmux::lines(&[
+        "list-panes",
+        "-t",
+        window,
+        "-f",
+        panes::IS_SIDEBAR,
+        "-F",
+        "#{pane_id}",
+    ])
+    .is_ok_and(|panes| !panes.is_empty())
 }
 
 fn client_window(client: &str) -> Option<String> {
@@ -133,7 +141,7 @@ fn select_sidebar(client: Option<&str>) {
         "-t",
         &window,
         "-f",
-        "#{==:#{pane_title},agenmux}",
+        panes::IS_SIDEBAR,
         "-F",
         "#{pane_id}",
     ])

--- a/tests/legacy-name-allowlist.txt
+++ b/tests/legacy-name-allowlist.txt
@@ -25,10 +25,10 @@ src/main.rs:    if let Some(d) = compat_env("AGENMUX_DIR", "AGENTS_MON_DIR") {
 src/notifications/macos.rs:    const LEGACY_APP: &str = "Applications/AgentsMon.app/Contents/MacOS/agents-mon-notifier";
 src/panes.rs:            || option.starts_with("@agents-mon-layout-@")
 src/panes.rs:            || option.starts_with("@agents-mon-winsize-@")
-src/panes.rs:        if !matches!(title, "agenmux" | "agents-mon") {
 src/panes.rs:    let _ = tmux::command_status(&["set-option", "-gu", "@agents-mon-control-client"]);
 src/panes.rs:    let _ = tmux::command_status(&["set-option", "-gu", "@agents-mon-on"]);
 src/panes.rs:    let legacy_option = format!("@agents-mon-layout-{window}");
+src/panes.rs:    let sidebar_filter = ["#{||:", IS_SIDEBAR, ",#{==:#{pane_title},agents-mon}}"].concat();
 src/release.rs:                    || value == format!("agents-mon {version}")
 src/release.rs:        "agents-mon"
 src/release.rs:        package.join("target/release/agents-mon")

--- a/tests/plugin.rs
+++ b/tests/plugin.rs
@@ -180,6 +180,113 @@ fn teardown_removes_legacy_sidebar_panes() {
 }
 
 #[test]
+fn pane_add_kills_restored_ghost_shell() {
+    let tmux = TestTmux::new("restored-ghost");
+    let window = tmux.text(&["display-message", "-p", "#{window_id}"]);
+    let original_panes = tmux
+        .text(&["list-panes", "-t", &window, "-F", "#{pane_id}"])
+        .lines()
+        .count();
+    let ghost = tmux.text(&[
+        "split-window",
+        "-hbf",
+        "-l",
+        "30",
+        "-d",
+        "-P",
+        "-F",
+        "#{pane_id}",
+        "exec sh",
+    ]);
+    tmux.assert_tmux(&["set-option", "-g", "@agenmux-on", "1"]);
+    tmux.assert_tmux(&["set-option", "-g", "@agenmux-width", "30"]);
+
+    assert_success(tmux.bin(&["pane-add", &window]), "pane-add restored ghost");
+
+    let panes = tmux.text(&[
+        "list-panes",
+        "-t",
+        &window,
+        "-F",
+        "#{pane_id}\t#{pane_title}\t#{@agenmux}",
+    ]);
+    assert!(
+        !panes.lines().any(|line| line.starts_with(&ghost)),
+        "{panes}"
+    );
+    assert_eq!(panes.lines().count(), original_panes + 1, "{panes}");
+    assert_eq!(
+        panes
+            .lines()
+            .filter(|line| line.ends_with("\tagenmux\t1"))
+            .count(),
+        1,
+        "{panes}"
+    );
+}
+
+#[test]
+fn pane_add_keeps_leftmost_non_shell_pane() {
+    let tmux = TestTmux::new("leftmost-non-shell");
+    let window = tmux.text(&["display-message", "-p", "#{window_id}"]);
+    let pane = tmux.text(&[
+        "split-window",
+        "-hbf",
+        "-l",
+        "30",
+        "-d",
+        "-P",
+        "-F",
+        "#{pane_id}",
+        "exec sleep 60",
+    ]);
+    tmux.assert_tmux(&["set-option", "-g", "@agenmux-on", "1"]);
+    tmux.assert_tmux(&["set-option", "-g", "@agenmux-width", "30"]);
+
+    assert_success(tmux.bin(&["pane-add", &window]), "pane-add non-shell");
+
+    let panes = tmux.text(&[
+        "list-panes",
+        "-t",
+        &window,
+        "-F",
+        "#{pane_id}\t#{pane_title}\t#{@agenmux}",
+    ]);
+    assert!(panes.lines().any(|line| line.starts_with(&pane)), "{panes}");
+    assert_eq!(
+        panes
+            .lines()
+            .filter(|line| line.ends_with("\tagenmux\t1"))
+            .count(),
+        1,
+        "{panes}"
+    );
+}
+
+#[test]
+fn teardown_finds_sidebar_by_pane_option() {
+    let tmux = TestTmux::new("option-teardown");
+    let window = tmux.text(&["display-message", "-p", "#{window_id}"]);
+    tmux.assert_tmux(&["set-option", "-g", "@agenmux-on", "1"]);
+    assert_success(tmux.bin(&["pane-add", &window]), "pane-add tagged sidebar");
+    let pane = tmux.text(&[
+        "list-panes",
+        "-t",
+        &window,
+        "-f",
+        "#{==:#{@agenmux},1}",
+        "-F",
+        "#{pane_id}",
+    ]);
+    tmux.assert_tmux(&["select-pane", "-t", &pane, "-T", "retitled"]);
+
+    assert_success(tmux.bin(&["teardown"]), "teardown tagged sidebar");
+
+    let panes = tmux.text(&["list-panes", "-t", &window, "-F", "#{pane_id}"]);
+    assert!(!panes.lines().any(|candidate| candidate == pane));
+}
+
+#[test]
 fn mirror_add_is_idempotent_under_concurrent_calls() {
     let tmux = TestTmux::new("mirror-race");
     let window = tmux.text(&["display-message", "-p", "#{window_id}"]);

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -373,7 +373,7 @@ printf '%s\n' "$*" >> "$TMUX_STUB_LOG"
 case "$*" in
   "show-option -gqv @agenmux-on") printf '1\n' ;;
   "list-windows -a -F "*window_panes*) printf '@sb\t1\ts1\n' ;;
-  "list-panes -t @sb -F #{pane_title}") printf 'agenmux\n' ;;
+  "list-panes -t @sb -f "*" -F #{pane_id}") printf '%%1\n' ;;
   "list-clients "*"-F #{client_name}") printf 'c1\n' ;;
   "display-message -p -c c1 #{window_id}") printf '@other\n' ;;
   "list-windows -t s1 -F "*window_last_flag*) printf '@sb\t0\n@last\t1\n' ;;
@@ -401,7 +401,7 @@ printf '%s\n' "$*" >> "$TMUX_STUB_LOG"
 case "$*" in
   "show-option -gqv @agenmux-on") printf '1\n' ;;
   "list-windows -a -F "*window_panes*) printf '@sb\t1\ts1\n' ;;
-  "list-panes -t @sb -F #{pane_title}") printf 'agenmux\n' ;;
+  "list-panes -t @sb -f "*" -F #{pane_id}") printf '%%1\n' ;;
   "list-clients "*"-F #{client_name}") printf 'c1\n' ;;
   "display-message -p -c c1 #{window_id}") printf '@sb\n' ;;
   "list-windows -t s1 -F "*window_last_flag*) printf '@sb\t0\n@last\t1\n' ;;


### PR DESCRIPTION
## Summary
- remove idle shell panes restored from processless sidebars before splitting
- tag sidebars with `@agenmux` so cleanup survives title changes
- document restore behavior and add regression coverage

## Testing
- `PATH="$HOME/.cargo/bin:$PATH" cargo test`
- `tests/run.sh`