### PR TITLE
Fix delayed agent discovery in sidebar

### DIFF
--- a/src/procs.rs
+++ b/src/procs.rs
@@ -130,9 +130,9 @@ pub fn identify(
     None
 }
 
-/// (pane_id, pane_pid, cmd) -> agent name or None; invalidates itself when
-/// the pane's foreground command changes.
-pub type IdentCache = HashMap<(String, u32, String), Option<String>>;
+/// (pane_id, pane_pid, cmd) -> identified agent name; unidentified panes retry
+/// on the next scan because wrappers can spawn an agent without changing this key.
+pub type IdentCache = HashMap<(String, u32, String), String>;
 
 #[cfg(test)]
 mod tests {

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -50,11 +50,12 @@ pub fn scan(
         }
         let pid: u32 = pid.parse().unwrap_or(0);
         let key = (pane.to_string(), pid, cmd.to_string());
-        let name = cache.get(&key).cloned().unwrap_or_else(|| {
-            procs::identify(confs, &mut snap, pid, cmd).map(|i| confs[i].name.clone())
-        });
-        seen.insert(key, name.clone());
+        let name = cache
+            .get(&key)
+            .cloned()
+            .or_else(|| procs::identify(confs, &mut snap, pid, cmd).map(|i| confs[i].name.clone()));
         let Some(name) = name else { continue };
+        seen.insert(key, name.clone());
         let Some(idx) = confs.iter().position(|c| c.name == name) else {
             continue; // conf removed since cached
         };

--- a/tests/navigation.sh
+++ b/tests/navigation.sh
@@ -446,9 +446,10 @@ picker_return=''
 for _ in $(seq 1 40); do
   picker_table="$(tmux -S "$sock" display-message -p -c "$client" \
     '#{client_key_table}')"
-  picker_return="$(tmux -S "$sock" capture-pane -p -t "$sidebar" |
-    sed -n '/❯/p' | head -n 1)"
-  if [ "$picker_table" = agenmux ] && [ "$picker_return" = "$picker_before" ]; then
+  picker_frame="$(tmux -S "$sock" capture-pane -p -t "$sidebar")"
+  picker_return="$(printf '%s\n' "$picker_frame" | sed -n '/❯/p' | head -n 1)"
+  if [ "$picker_table" = agenmux ] && [ -n "$picker_return" ] &&
+    ! printf '%s\n' "$picker_frame" | grep -Eq 'no releases found|↵ switch'; then
     picker_reclaimed=1
     break
   fi
@@ -469,7 +470,7 @@ third="$second"
 for _ in $(seq 1 20); do
   third="$(tmux -S "$sock" capture-pane -p -t "$sidebar" |
     sed -n '/❯/p' | head -n 1)"
-  [ "$third" = "$picker_before" ] && break
+  [ "$third" = "$picker_return" ] && break
   sleep 0.1
 done
 
@@ -844,7 +845,7 @@ if [ "$table" = agenmux ] && [ "$initial_focus" = agenmux ] &&
   [ "$picker_open" -eq 1 ] && [ "$picker_reclaimed" -eq 1 ] &&
   [ "$table_after_j" = agenmux ] &&
   printf '%s' "$control_flags" | grep -Fq control-mode &&
-  [ "$second" != "$picker_return" ] && [ "$third" = "$picker_before" ] &&
+  [ "$second" != "$picker_return" ] && [ "$third" = "$picker_return" ] &&
   [ "$wheel_down" != "$third" ] && [ "$wheel_up" = "$third" ] &&
   [ "$wheel_delay_works" -eq 1 ] &&
   [ "$return_table" = agenmux ] && [ "$return_focus" = agenmux ] &&

--- a/tests/navigation.sh
+++ b/tests/navigation.sh
@@ -414,15 +414,21 @@ for _ in $(seq 1 20); do
   printf '%s' "$control_flags" | grep -Fq control-mode && break
   sleep 0.05
 done
+picker_start="$(tmux -S "$sock" capture-pane -p -t "$sidebar" |
+  sed -n '/❯/p' | head -n 1)"
 printf 'k' >&9
+picker_reset="$picker_start"
 for _ in $(seq 1 20); do
   picker_reset="$(tmux -S "$sock" capture-pane -p -t "$sidebar" |
     sed -n '/❯/p' | head -n 1)"
-  [ "$picker_reset" = "$first" ] && break
+  [ -n "$picker_reset" ] && [ "$picker_reset" != "$picker_start" ] && break
   sleep 0.1
 done
-picker_before="$(tmux -S "$sock" capture-pane -p -t "$sidebar" |
-  sed -n '/❯/p' | head -n 1)"
+[ "$picker_reset" != "$picker_start" ] || {
+  echo "FAIL navigation-key-table: pre-picker cursor did not move"
+  exit 1
+}
+picker_before="$picker_reset"
 printf 'u' >&9
 picker_open=0
 for _ in $(seq 1 40); do
@@ -442,7 +448,7 @@ for _ in $(seq 1 40); do
     '#{client_key_table}')"
   picker_return="$(tmux -S "$sock" capture-pane -p -t "$sidebar" |
     sed -n '/❯/p' | head -n 1)"
-  if [ "$picker_table" = agenmux ] && [ -n "$picker_return" ]; then
+  if [ "$picker_table" = agenmux ] && [ "$picker_return" = "$picker_before" ]; then
     picker_reclaimed=1
     break
   fi

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -584,6 +584,8 @@ if [ "$fail" -eq 0 ] && command -v tmux >/dev/null && [ -x "$BIN" ]; then
   tmp="$(mktemp -d)"
   T="tmux -S $tmp/sock -f /dev/null"
   mkdir -p "$tmp/bin"
+  printf '#!/bin/sh\nwhile :; do sleep 10; done\n' >"$tmp/claude"
+  chmod +x "$tmp/claude"
   printf '#!/bin/sh\nexec %s -S %s "$@"\n' "$(command -v tmux)" "$tmp/sock" \
     >"$tmp/bin/tmux"
   chmod +x "$tmp/bin/tmux"
@@ -620,11 +622,14 @@ if [ "$fail" -eq 0 ] && command -v tmux >/dev/null && [ -x "$BIN" ]; then
   live_sidebar="$($T list-panes -t t: -F '#{pane_id}	#{pane_title}' |
     awk -F'\t' '$2 == "agenmux" { print $1; exit }')"
   live_frame="$($T capture-pane -p -t "$live_sidebar")"
-  $T new-window -t t: 'exec sleep 60'
-  sleep 1.5
+  $T new-window -t t: "sh -c 'sleep 1; exec \"$tmp/claude\"'"
+  sleep 3
   neww="$($T display-message -p -t t: '#{window_id}')"
   new_ok=0
   $T list-panes -t "$neww" -F '#{pane_title}' | grep -qx agenmux && new_ok=1
+  delayed_sidebar="$($T list-panes -t "$neww" -F '#{pane_id}	#{pane_title}' |
+    awk -F'\t' '$2 == "agenmux" { print $1; exit }')"
+  delayed_frame="$($T capture-pane -p -t "$delayed_sidebar" -S -)"
   # concurrent adds must not double-split. One window switch fires two [43]
   # hooks, so racing pane-add commands are routine, and a check-then-split
   # without the native lock would let every one of them through.
@@ -672,12 +677,13 @@ if [ "$fail" -eq 0 ] && command -v tmux >/dev/null && [ -x "$BIN" ]; then
     [ "$keys_ok" -eq 1 ] && [ "$control_ok" -eq 1 ] && [ "$stayed" -gt 0 ] &&
     printf '%s\n' "$live_frame" | grep -Fq agents &&
     [ "$before" = "$after" ] && [ "$new_ok" -eq 1 ] &&
+    printf '%s\n' "$delayed_frame" | grep -Fq claude &&
     [ "$raced" -eq 1 ] && [ "$widths" = 45 ] && [ "$optw" = 45 ] &&
     [ "$optw2" = 45 ] &&
     [ "$left" -eq 0 ] && [ ! -f "$tmp/agenmux-frame" ]; then
     echo "ok   mirror-mode-no-bump-lifecycle"
   else
-    echo "FAIL mirror-mode-no-bump-lifecycle: mirrors=$mirrors processless=$processless focus=$focus_kept keys=$keys_ok control=$control_ok stayed=$stayed live=$([ -n "$live_frame" ] && echo y || echo n) layout-same=$([ "$before" = "$after" ] && echo y || echo n) new=$new_ok raced=$raced widths=$widths optw=$optw optw2=$optw2 left=$left"
+    echo "FAIL mirror-mode-no-bump-lifecycle: mirrors=$mirrors processless=$processless focus=$focus_kept keys=$keys_ok control=$control_ok stayed=$stayed live=$([ -n "$live_frame" ] && echo y || echo n) layout-same=$([ "$before" = "$after" ] && echo y || echo n) new=$new_ok delayed=$([ -n "$delayed_frame" ] && printf '%s\n' "$delayed_frame" | grep -Fq claude && echo y || echo n) raced=$raced widths=$widths optw=$optw optw2=$optw2 left=$left"
     fail=1
   fi
   $T kill-server 2>/dev/null || true


### PR DESCRIPTION
## Summary
- retry agent identification when an earlier process snapshot found no agent
- cache only successful pane identities
- cover wrappers that spawn an agent after the sidebar’s initial scan

## Testing
- `cargo test -- --test-threads=1`
- `cargo build`
- `AGENMUX_BIN=target/debug/agenmux bash tests/run.sh`
- live tmux verification with delayed Claude startup: absent before fork, then working, then idle in the sidebar