### PR TITLE
Resolve pi sidebar subject per pane

### DIFF
--- a/agents/pi.conf
+++ b/agents/pi.conf
@@ -9,14 +9,32 @@ CHECK_ORDER="ws"
 TITLE_STRIP='^π - '
 
 # unnamed sessions carry no title subject — pull session name / first user
-# message from the newest session file for the pane's cwd
-# pi stubs an empty session file on launch, so walk newest-first and take the
-# first file that yields anything
-# ponytail: newest-with-subject heuristic; wrong pick if two pi sessions share a cwd
-SUBJECT_CMD='for f in $(ls -t "$HOME/.pi/agent/sessions/-${path//\//-}--"/*.jsonl 2>/dev/null); do
+# message from the pane's session file. Nothing in pi ties a pane to a file
+# (several pi in one cwd share a sessions dir, /new opens a new file), so:
+# candidates newest-modified first, those created after the agent process
+# started ($started, UTC YYYY-MM-DDTHH-MM-SS — the prefix pi names files
+# with) ahead of the rest (resumed sessions predate it); the first whose last
+# user message is visible in the scrollback of $pane belongs to it — pi
+# renders prompts as " <text>" lines, so short ones must match a whole line
+# and long ones a 40-char line prefix ("go" alone matches every pane). No
+# scrollback match (cleared screen, history limit, fresh /new): first that
+# yields anything. pi stubs an empty file on launch, hence the yield check.
+# ponytail: ties only if two panes got the same prompt
+SUBJECT_CMD='dir="$HOME/.pi/agent/sessions/-${path//\//-}--"
+  all=$(ls -t "$dir"/*.jsonl 2>/dev/null)
+  own=$(printf "%s\n" $all | awk -v s="$started" -F/ "s != \"\" && substr(\$NF, 1, 19) >= s")
+  seen=$(tmux capture-pane -p -t "$pane" -S - 2>/dev/null)
+  pick=
+  for f in $own $all; do
+    last=$(grep "\"type\":\"message\".*\"role\":\"user\"" "$f" | tail -n 1 | sed -nE "s/.*\"(text|content)\":\"([^\"\\\\]{1,40}).*/\2/p")
+    [ -n "$last" ] || continue
+    x=-x; [ ${#last} -eq 40 ] && x=
+    printf "%s\n" "$seen" | grep -q $x -F -- " $last" && { pick=$f; break; }
+  done
+  for f in $pick $own $all; do
     s=$({
       grep "\"type\":\"session_info\"" "$f" | tail -n 1 | sed -nE "s/.*\"name\":\"([^\"]*)\".*/\1/p"
-      grep -m 1 "\"role\":\"user\"" "$f" | sed -nE "s/.*\"(text|content)\":\"([^\"]*)\".*/\2/p"
+      grep -m 1 "\"type\":\"message\".*\"role\":\"user\"" "$f" | sed -nE "s/.*\"(text|content)\":\"([^\"]*)\".*/\2/p"
     } | grep -m 1 .)
     [ -n "$s" ] && { printf "%s\n" "$s"; break; }
   done'

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -63,14 +63,23 @@ pub fn subject(conf: &AgentConf, title: &str, screen: &str, path: &str) -> Strin
     t.replace('\t', " ")
 }
 
-/// Run SUBJECT_CMD ($path = pane cwd). One bash fork — callers must cache
-/// (scan.rs SubjectCache); forking per scan tick stalls the sidebar loop.
-pub fn subject_cmd(conf: &AgentConf, path: &str) -> Option<String> {
+/// Run SUBJECT_CMD ($pane = tmux pane id, $path = pane cwd, $started = agent
+/// process start as UTC YYYY-MM-DDTHH-MM-SS, empty when unknown). One bash
+/// fork — callers must cache (scan.rs SubjectCache); forking per scan tick
+/// stalls the sidebar loop.
+pub fn subject_cmd(
+    conf: &AgentConf,
+    pane: &str,
+    path: &str,
+    started: Option<u64>,
+) -> Option<String> {
     let cmd = conf.subject_cmd.as_ref()?;
     let out = std::process::Command::new("bash")
         .arg("-c")
         .arg(cmd)
+        .env("pane", pane)
         .env("path", path)
+        .env("started", started.map(utc_stamp).unwrap_or_default())
         .output()
         .ok()?;
     Some(
@@ -80,10 +89,40 @@ pub fn subject_cmd(conf: &AgentConf, path: &str) -> Option<String> {
     )
 }
 
+/// Epoch secs -> "YYYY-MM-DDTHH-MM-SS" UTC, the prefix pi uses for session
+/// file names, so confs can compare by plain string order.
+fn utc_stamp(secs: u64) -> String {
+    let (days, rem) = (secs / 86_400, secs % 86_400);
+    // civil-from-days (H. Hinnant), proleptic Gregorian
+    let z = days as i64 + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z.rem_euclid(146_097);
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = yoe + era * 400 + i64::from(m <= 2);
+    format!(
+        "{y:04}-{m:02}-{d:02}T{:02}-{:02}-{:02}",
+        rem / 3600,
+        rem % 3600 / 60,
+        rem % 60
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::conf::load_conf;
+
+    #[test]
+    fn utc_stamp_matches_pi_session_prefix() {
+        assert_eq!(utc_stamp(0), "1970-01-01T00-00-00");
+        // 2026-09-03T10:25:01Z
+        assert_eq!(utc_stamp(1_788_431_101), "2026-09-03T10-25-01");
+        assert_eq!(utc_stamp(951_782_400), "2000-02-29T00-00-00");
+    }
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     fn conf(body: &str) -> AgentConf {

--- a/src/procs.rs
+++ b/src/procs.rs
@@ -35,6 +35,11 @@ impl Snapshot {
     /// BFS over the pane's process tree, root included (agent may be the
     /// pane command itself); argv fetched for just this subtree.
     fn descendant_argvs(&mut self, root: u32) -> Vec<Vec<String>> {
+        self.descendants(root).into_iter().map(|(_, a)| a).collect()
+    }
+
+    /// (start epoch secs, argv) per process in the pane's subtree.
+    fn descendants(&mut self, root: u32) -> Vec<(u64, Vec<String>)> {
         let mut queue = vec![root];
         let mut i = 0;
         while i < queue.len() {
@@ -52,14 +57,30 @@ impl Snapshot {
         pids.iter()
             .filter_map(|pid| self.sys.process(*pid))
             .map(|p| {
-                p.cmd()
+                let argv = p
+                    .cmd()
                     .iter()
                     .map(|s| s.to_string_lossy().into_owned())
-                    .collect::<Vec<String>>()
+                    .collect::<Vec<String>>();
+                (p.start_time(), argv)
             })
-            .filter(|argv| !argv.is_empty())
+            .filter(|(_, argv)| !argv.is_empty())
             .collect()
     }
+}
+
+/// Start time (epoch secs) of the agent process in a pane's subtree — the
+/// earliest one when wrappers re-exec the same bin.
+pub fn agent_start(conf: &AgentConf, snap: &mut Option<Snapshot>, pane_pid: u32) -> Option<u64> {
+    let snap = snap.get_or_insert_with(Snapshot::take);
+    snap.descendants(pane_pid)
+        .into_iter()
+        .filter(|(_, argv)| {
+            conf.bins.iter().any(|b| b == normalize_bin(&argv[0]))
+                || agent_for_argv(std::slice::from_ref(conf), argv).is_some()
+        })
+        .map(|(t, _)| t)
+        .min()
 }
 
 /// path/wrapper -> bare name (strip dir, .js/.cmd/.exe)

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -75,7 +75,9 @@ pub fn scan(
                 Some((_, s)) => subject = s.clone(),
                 None => {
                     let t0 = std::time::Instant::now();
-                    subject = crate::detect::subject_cmd(&confs[idx], path).unwrap_or_default();
+                    let started = procs::agent_start(&confs[idx], &mut snap, pid);
+                    subject = crate::detect::subject_cmd(&confs[idx], pane, path, started)
+                        .unwrap_or_default();
                     crate::tmux::debug_note(&format!(
                         "subject_cmd {pane} {}ms",
                         t0.elapsed().as_millis()


### PR DESCRIPTION
## Problem

Several pi panes in one cwd showed the same sidebar subject. Two causes:

- `SUBJECT_CMD` in `agents/pi.conf` only knew the pane cwd and took the newest session file, so every pane sharing a directory resolved to the same file, most visibly right after the sidebar (re)starts and its subject cache is cold.
- Its user-message grep matched pi-stamp extension entries, which carry `"role":"user"` without text and come last in the file, so extraction often came up empty and skipped the right file.

## Fix

- `SUBJECT_CMD` now receives `$pane` and `$started` (agent process start, UTC in pi's session-filename form, from a new `procs::agent_start`).
- pi.conf prefers files created after the process started, then picks the one whose last user message is visible in the pane scrollback: whole-line match for short prompts, 40-char line prefix for long ones (so "go" no longer matches every pane). No match falls back to the previous newest-file behaviour.
- Both greps require `"type":"message"`.

Known gap: a fresh `/new` with no prompt yet has nothing to match and shows the fallback until its first prompt.

## Tests

- `cargo test`: new `utc_stamp_matches_pi_session_prefix`
- `tests/run.sh`: all ok
- Verified live: three pi panes in one cwd now show their own subjects.
