### PR TITLE
Add Google site verification metadata

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="google-site-verification"
+      content="OnIVypIV57HTxa0Z1PIkRBDGppc45tJ0cpldN3qgCH0"
+    />
     <title>agenmux — tmux plugin for monitoring AI coding agents</title>
     <meta
       name="description"


### PR DESCRIPTION
## Summary
- add Google Search Console site-verification metadata to landing page

## Verification
- parsed `site/index.html` and confirmed exactly one matching verification meta tag
- `git diff --check`
- HTML LSP diagnostics clean
