### PR TITLE
Release agenmux v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agenmux"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "libc",
  "mac-usernotifications",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agenmux"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 [dependencies]

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,17 +1,19 @@
-# agenmux v0.3.0
+# agenmux v0.3.1
 
 ## What's changed
 
-### agenmux rebrand
+### Fixes
 
-- Renamed the runtime, binaries, tmux options, configuration path, release artifacts, and documentation to agenmux ([#37](https://github.com/snirt/agenmux/pull/37)).
-- Preserved `agents-mon` entrypoints, options, environment variables, config paths, package launchers, and release state as compatibility inputs for one release cycle.
-- Renamed the macOS notification helper to `Agenmux.app` with bundle ID `io.github.snirt.agenmux`.
+- Made runtime paths survive `TMPDIR` changes and rejected malformed `TMUX` values ([#41](https://github.com/snirt/agenmux/pull/41)).
+- Removed restored ghost panes from the sidebar ([#42](https://github.com/snirt/agenmux/pull/42)).
+- Fixed delayed agent discovery and stabilized sidebar navigation input ([#43](https://github.com/snirt/agenmux/pull/43)).
+- Resolved each Pi pane's subject independently instead of sharing session metadata ([#46](https://github.com/snirt/agenmux/pull/46)).
 
-### Developer workflow
+### Website
 
-- Added `make dev-use` and `make dev-stop` for switching the active tmux server between local debug and release binaries.
-- Added debug build timestamps to sidebar titles while keeping release titles versioned.
+- Standardized lowercase agenmux branding across documentation ([#39](https://github.com/snirt/agenmux/pull/39)).
+- Added agenmux icons and favicon assets ([#44](https://github.com/snirt/agenmux/pull/44)).
+- Improved search metadata and added Google site verification ([#47](https://github.com/snirt/agenmux/pull/47), [#48](https://github.com/snirt/agenmux/pull/48)).
 
 ### Assets
 
@@ -21,4 +23,4 @@
 - macOS aarch64
 - SHA-256 checksums
 
-**Full changelog:** <https://github.com/snirt/agenmux/compare/v0.2.1...v0.3.0>
+**Full changelog:** <https://github.com/snirt/agenmux/compare/v0.3.0...v0.3.1>

--- a/docs/plans/2026-09-03-version-bump-0.3.1.md
+++ b/docs/plans/2026-09-03-version-bump-0.3.1.md
@@ -1,0 +1,26 @@
+# agenmux 0.3.1 Version Bump Plan
+
+**Goal:** Prepare Agenmux v0.3.1 and submit version metadata plus curated release notes for review.
+
+**Approach:** Reuse Cargo and existing test commands. Keep publication and tagging out of pull request; tag merged commit when release is approved.
+
+## Files
+
+- `Cargo.toml` — bump package version to `0.3.1`.
+- `Cargo.lock` — record package version `0.3.1`.
+- `RELEASE_NOTES.md` — summarize merged changes from `v0.3.0` through `origin/master`.
+- `docs/plans/2026-09-03-version-bump-0.3.1.md` — record the reviewed bump procedure and publication handoff.
+
+## Checklist
+
+- [ ] Create `release/v0.3.1` from current `origin/master`.
+- [ ] Set package version to `0.3.1` in `Cargo.toml` and refresh `Cargo.lock` with Cargo.
+- [ ] Replace `RELEASE_NOTES.md` with v0.3.1 fixes, website updates, assets, and `v0.3.0...v0.3.1` comparison link.
+- [ ] Run `cargo test` and `./tests/run.sh`.
+- [ ] Verify `scripts/version.sh` prints `0.3.1` and `scripts/version.sh check-tag v0.3.1` passes.
+- [ ] Inspect exact diff and confirm no unrelated files, private data, or secret-like values are staged.
+- [ ] Commit as `chore: bump version to 0.3.1`, push `release/v0.3.1`, and open pull request against `master`.
+
+## Publication handoff
+
+After pull request merge, tag merged `master` commit as `v0.3.1` and push tag so release workflow builds and publishes assets. Do not tag pull-request commit.


### PR DESCRIPTION
## Summary

- bump Cargo package version to 0.3.1
- publish curated notes for changes since v0.3.0
- document the reviewed bump and post-merge tagging handoff

## Verification

- `mise exec rust@latest -- cargo test`
- `mise exec rust@latest -- ./tests/run.sh`
- `scripts/version.sh check-tag v0.3.1`

## Publication

Tag the merged `master` commit as `v0.3.1`; do not tag this pull-request commit.