### PR TITLE
Prevent mouse clicks passing through Versions screen

### DIFF
--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -1525,9 +1525,11 @@ impl Sidebar {
         let _ = std::fs::remove_file(&self.rows_file);
     }
 
-    /// Frame sink: stdout in tty mode; direct writes to the visible empty panes
-    /// in daemon mode.
-    fn emit(&mut self, frame: String, force: bool) {
+    /// Frame and click-row sink: stdout in tty mode; direct writes to visible
+    /// empty panes in daemon mode.
+    fn emit(&mut self, frame: String, rows: &str, force: bool) {
+        // Rows map must match what the click helper sees under each rendered row.
+        let _ = std::fs::write(&self.rows_file, rows);
         let changed = force || frame != self.last_frame;
         match &mut self.daemon {
             None => {
@@ -1711,8 +1713,7 @@ impl Sidebar {
             }
         }
         frame.push_str(&format!("{E}[J"));
-        let _ = std::fs::write(&self.rows_file, &vis);
-        self.emit(frame, force);
+        self.emit(frame, &vis, force);
     }
 
     /// Version picker: update or roll back to any release the last check saw.
@@ -1782,7 +1783,7 @@ impl Sidebar {
             }
             None => return,
         };
-        self.emit(text, force);
+        self.emit(text, "", force);
     }
 
     fn overlay_key(&mut self, key: Key) {

--- a/tests/navigation.sh
+++ b/tests/navigation.sh
@@ -440,6 +440,34 @@ for _ in $(seq 1 40); do
     }
   sleep 0.05
 done
+# A click over an agent row while the picker covers the list must focus the
+# picker, not jump through it to the sidebar row drawn underneath.
+tmux -S "$sock" switch-client -c "$client" -t "$work"
+tmux -S "$sock" switch-client -c "$client" -T root
+tmux -S "$sock" select-pane -t "$work"
+env TMPDIR="$tmp" TMUX="$sock,$server_pid,0" \
+  "$BIN" click "$sidebar" "$valid_row" "$client"
+picker_click_works=0
+for _ in $(seq 1 20); do
+  picker_click_table="$(tmux -S "$sock" display-message -p -c "$client" \
+    '#{client_key_table}')"
+  picker_click_focus="$(tmux -S "$sock" display-message -p -c "$client" \
+    '#{pane_id}')"
+  picker_click_frame="$(tmux -S "$sock" capture-pane -p -t "$sidebar")"
+  if [ "$picker_click_table" = agenmux ] &&
+    [ "$picker_click_focus" = "$sidebar" ] &&
+    printf '%s\n' "$picker_click_frame" | grep -Eq 'no releases found|↵ switch'; then
+    picker_click_works=1
+    break
+  fi
+  sleep 0.05
+done
+picker_click_rows=''
+picker_click_first=''
+if [ "$picker_click_works" -eq 0 ]; then
+  picker_click_rows="$(tr '\n' '|' 2>/dev/null <"$tmp/agenmux-rows" || true)"
+  picker_click_first="$(printf '%s\n' "$picker_click_frame" | sed -n '1p')"
+fi
 printf 'q' >&9
 picker_reclaimed=0
 picker_return=''
@@ -842,7 +870,8 @@ if [ "$table" = agenmux ] && [ "$initial_focus" = agenmux ] &&
   [ "$agent_missing_client_noop" -eq 1 ] &&
   [ "$vanished_sidebar_noop" -eq 1 ] &&
   [ "$valid_click_works" -eq 1 ] &&
-  [ "$picker_open" -eq 1 ] && [ "$picker_reclaimed" -eq 1 ] &&
+  [ "$picker_open" -eq 1 ] && [ "$picker_click_works" -eq 1 ] &&
+  [ "$picker_reclaimed" -eq 1 ] &&
   [ "$table_after_j" = agenmux ] &&
   printf '%s' "$control_flags" | grep -Fq control-mode &&
   [ "$second" != "$picker_return" ] && [ "$third" = "$picker_return" ] &&
@@ -862,6 +891,6 @@ if [ "$table" = agenmux ] && [ "$initial_focus" = agenmux ] &&
   [ "$notification_stale_noop" -eq 1 ]; then
   echo "ok   attached-client-jk-navigation"
 else
-  echo "FAIL navigation-key-table: table=$table initial-focus=[$initial_focus] initial-hint=[$inactive_hint_hidden/$initial_hint] chooser=[$chooser_open_unzoomed/$chooser_state/$chooser_width] ctrl-l=[$ctrl_l_works/$ctrl_l_table/$ctrl_l_focus] missing-client=[$missing_client_noop/$missing_client_table/$missing_secondary_table/$missing_client_focus] empty-click=[$empty_click_works/$empty_click_table/$secondary_click_table/$empty_click_focus/green=$empty_click_green] stale-click=[$stale_click_works/$stale_click_table/$stale_click_focus] non-agent=[$non_agent_locations_work/$location_table/$location_focus] agent-missing-client=[$agent_missing_client_noop/$agent_missing_primary_table/$agent_missing_secondary_table/$agent_missing_focus] vanished-sidebar=[$vanished_sidebar_noop/$vanished_sidebar_table/$vanished_sidebar_focus] valid-click=[$valid_click_works/$valid_click_table/$valid_click_focus/$valid_target] picker=[$picker_open/$picker_reclaimed/$picker_table/$picker_before/$picker_return] after-j=$table_after_j control=[$control/$control_flags] first=[$first] second=[$second] third=[$third] wheel=[$wheel_down/$wheel_up/delay=$wheel_delay_works/target=$wheel_delay_target] return=[$return_table/$return_focus] fourth=[$fourth] search=[$search_works/$search_targets/$search_table/$search_frame/$search_hint/accept=$search_accept_works/$accept_table/$accept_frame/$accept_hint/jk=$search_jk_works/$accepted_cursor/$filtered_cursor/blur=$search_blur_works/$blur_table/$blur_targets] filters=[$blocked_filter_works/$blocked_targets/$blocked_frame/$blocked_hint/$working_filter_works/$working_targets/$working_frame/$idle_filter_works/$idle_targets/$idle_frame/$all_filter_works/$all_targets/$all_frame] q-leave=[$q_left/$exit_table/$exit_focus] escape=[$escape_ready/$escape_reset/$escape_left/$escape_table/$escape_focus/$escape_frame] Q-close=[$close_ready/$q_closed/$close_table] notification-open=[$notification_open_works/$notification_stale_noop/$notification_client]"
+  echo "FAIL navigation-key-table: table=$table initial-focus=[$initial_focus] initial-hint=[$inactive_hint_hidden/$initial_hint] chooser=[$chooser_open_unzoomed/$chooser_state/$chooser_width] ctrl-l=[$ctrl_l_works/$ctrl_l_table/$ctrl_l_focus] missing-client=[$missing_client_noop/$missing_client_table/$missing_secondary_table/$missing_client_focus] empty-click=[$empty_click_works/$empty_click_table/$secondary_click_table/$empty_click_focus/green=$empty_click_green] stale-click=[$stale_click_works/$stale_click_table/$stale_click_focus] non-agent=[$non_agent_locations_work/$location_table/$location_focus] agent-missing-client=[$agent_missing_client_noop/$agent_missing_primary_table/$agent_missing_secondary_table/$agent_missing_focus] vanished-sidebar=[$vanished_sidebar_noop/$vanished_sidebar_table/$vanished_sidebar_focus] valid-click=[$valid_click_works/$valid_click_table/$valid_click_focus/$valid_target] picker=[$picker_open/click=$picker_click_works/$picker_click_table/$picker_click_focus/rows=$picker_click_rows/frame=$picker_click_first/$picker_reclaimed/$picker_table/$picker_before/$picker_return] after-j=$table_after_j control=[$control/$control_flags] first=[$first] second=[$second] third=[$third] wheel=[$wheel_down/$wheel_up/delay=$wheel_delay_works/target=$wheel_delay_target] return=[$return_table/$return_focus] fourth=[$fourth] search=[$search_works/$search_targets/$search_table/$search_frame/$search_hint/accept=$search_accept_works/$accept_table/$accept_frame/$accept_hint/jk=$search_jk_works/$accepted_cursor/$filtered_cursor/blur=$search_blur_works/$blur_table/$blur_targets] filters=[$blocked_filter_works/$blocked_targets/$blocked_frame/$blocked_hint/$working_filter_works/$working_targets/$working_frame/$idle_filter_works/$idle_targets/$idle_frame/$all_filter_works/$all_targets/$all_frame] q-leave=[$q_left/$exit_table/$exit_focus] escape=[$escape_ready/$escape_reset/$escape_left/$escape_table/$escape_focus/$escape_frame] Q-close=[$close_ready/$q_closed/$close_table] notification-open=[$notification_open_works/$notification_stale_noop/$notification_client]"
   exit 1
 fi


### PR DESCRIPTION
## Summary

- publish the click-row map from the shared frame sink
- clear clickable rows whenever Help or Versions overlays are rendered
- cover Versions-overlay clicks through the public click command
- include row-map and frame context in navigation failure diagnostics

## Testing

- `cargo test`
- `bash tests/run.sh` (passed repeatedly)
- `bash tests/navigation.sh` (passed repeatedly standalone)
- `cargo fmt --check`

Closes #12
