### PR TITLE
Fix stale dev binary recovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,10 @@
 - Before live verification, inspect `@agenmux-bin`, derive that binary's plugin root, and confirm its loaded `agents/*.conf`. Never assume the current checkout is deployed.
 - Restart the active daemon after config changes, then verify the monitored pane reports `working` during activity and `idle` after completion.
 
+## Plans
+
+- Store implementation plans in `docs/plans/`. Never write plans under `docs/superpowers/`.
+
 ## Module boundaries
 
 - Before splitting an existing file into multiple modules, ask for approval unless the task explicitly requests the split.

--- a/agenmux.tmux
+++ b/agenmux.tmux
@@ -13,6 +13,7 @@ option() {
   fi
 }
 DEFAULT_BIN="$CURRENT_DIR/target/release/agenmux"
+DEBUG_BIN="$CURRENT_DIR/target/debug/agenmux"
 BIN="$(option @agenmux-bin)"
 [ -n "$BIN" ] || BIN="$DEFAULT_BIN"
 
@@ -32,6 +33,17 @@ engine_current() {
 # beat the eager installer, so serialize with it before handing runtime control
 # to Rust. This is bootstrap, not a second sidebar/toggle implementation.
 if [ "${1:-}" = activate ]; then
+  if [ "$BIN" != "$DEFAULT_BIN" ] && [ ! -x "$BIN" ]; then
+    tmux set-option -gu @agenmux-bin 2>/dev/null || true
+    tmux set-option -gu @agents-mon-bin 2>/dev/null || true
+    if [ -x "$DEBUG_BIN" ]; then
+      BIN="$DEBUG_BIN"
+      tmux set-option -g @agenmux-bin "$BIN"
+      AGENMUX_DIR="$CURRENT_DIR" "$BIN" setup || exit 1
+    else
+      BIN="$DEFAULT_BIN"
+    fi
+  fi
   mode="${2:-}"
   client="${3:-}"
   if ! engine_current; then

--- a/docs/plans/2026-09-06-stale-dev-binary-recovery.md
+++ b/docs/plans/2026-09-06-stale-dev-binary-recovery.md
@@ -1,0 +1,36 @@
+# Stale Dev Binary Recovery Implementation Plan
+
+**Goal:** Recover automatically when `@agenmux-bin` points to a removed worktree build.
+
+**Architecture:** Keep recovery at existing shell entry points. Activation clears a missing custom override and adopts the current checkout's debug engine when available, otherwise resuming normal release installation. Dev switching skips teardown only when the previous executable no longer exists, then installs the freshly built debug engine and restores active state.
+
+**Tech Stack:** Bash, tmux integration tests.
+
+## Global Constraints
+
+- No new configuration or dependencies.
+- Preserve valid custom binary behavior.
+- Test observable entry-point behavior.
+
+### Task 1: Regression checks
+
+**Files:**
+
+- Create: `tests/stale-dev-bin-recovery.sh`
+- Modify: `tests/run.sh`
+
+- [x] Exercise `agenmux.tmux activate` with missing `@agenmux-bin`; require stale override removal and current debug engine invocation.
+- [x] Exercise `scripts/dev-bin.sh use` with missing prior binary; require successful debug switch without teardown.
+- [x] Run focused test and confirm failure before implementation.
+
+### Task 2: Minimal recovery
+
+**Files:**
+
+- Modify: `agenmux.tmux`
+- Modify: `scripts/dev-bin.sh`
+
+- [x] Clear missing custom binary override before activation engine checks.
+- [x] Skip previous-engine teardown when previous executable is absent.
+- [x] Run focused test and full suite.
+- [x] Verify live stale-path recovery, inspect diff/status, and scan changed files for private or secret data.

--- a/scripts/dev-bin.sh
+++ b/scripts/dev-bin.sh
@@ -34,10 +34,6 @@ fi
 old_option=""
 [ -z "$old_option_name" ] || old_option="$(tmux show-option -gqv "$old_option_name")"
 current="${old_option:-$RELEASE}"
-[ -x "$current" ] || {
-  echo "agenmux: current binary not found: $current" >&2
-  exit 1
-}
 was_on="$(tmux show-option -gqv @agenmux-on)"
 [ -n "$was_on" ] || was_on="$(tmux show-option -gqv @agents-mon-on)"
 old_control="$(tmux show-option -gqv @agenmux-control-client)"
@@ -57,12 +53,14 @@ start_bin() {
     { [ -z "$was_on" ] || AGENMUX_DIR="$DIR" "$1" toggle; }
 }
 
-"$current" teardown || exit 1
-if [ -n "$old_control" ]; then
-  for ((i = 0; i < 80; i++)); do
-    tmux list-clients -F '#{client_name}' 2>/dev/null | grep -Fxq "$old_control" || break
-    sleep 0.1
-  done
+if [ -x "$current" ]; then
+  "$current" teardown || exit 1
+  if [ -n "$old_control" ]; then
+    for ((i = 0; i < 80; i++)); do
+      tmux list-clients -F '#{client_name}' 2>/dev/null | grep -Fxq "$old_control" || break
+      sleep 0.1
+    done
+  fi
 fi
 
 select_bin "$next" || exit 1
@@ -70,9 +68,13 @@ if ! start_bin "$next"; then
   "$next" teardown >/dev/null 2>&1 || true
   tmux set-option -gu @agenmux-bin 2>/dev/null || true
   tmux set-option -gu @agents-mon-bin 2>/dev/null || true
-  [ -z "$old_option_name" ] || tmux set-option -g "$old_option_name" "$old_option"
-  start_bin "$current" >/dev/null 2>&1 || true
-  echo "agenmux: switch failed; restored previous binary" >&2
+  if [ -x "$current" ]; then
+    [ -z "$old_option_name" ] || tmux set-option -g "$old_option_name" "$old_option"
+    start_bin "$current" >/dev/null 2>&1 || true
+    echo "agenmux: switch failed; restored previous binary" >&2
+  else
+    echo "agenmux: switch failed; previous binary unavailable" >&2
+  fi
   exit 1
 fi
 

--- a/tests/legacy-name-allowlist.txt
+++ b/tests/legacy-name-allowlist.txt
@@ -2,6 +2,7 @@
 .github/workflows/build.yml:            > "dist/$package/target/release/agents-mon"
 .github/workflows/build.yml:            chmod +x "dist/$package/target/release/agents-mon-notifier"
 .github/workflows/build.yml:          chmod +x "dist/$package/target/release/agents-mon"
+agenmux.tmux:    tmux set-option -gu @agents-mon-bin 2>/dev/null || true
 agenmux.tmux:  legacy="${canonical/@agenmux-/@agents-mon-}"
 scripts/dev-bin.sh:  old_option_name="@agents-mon-bin"
 scripts/dev-bin.sh:  tmux set-option -gu @agents-mon-bin 2>/dev/null || true

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -21,6 +21,9 @@ fi
 if ! "$DIR/tests/make-release.sh"; then
   fail=1
 fi
+if ! "$DIR/tests/stale-dev-bin-recovery.sh"; then
+  fail=1
+fi
 
 if [ "$fail" -eq 0 ]; then
   version="$(bash "$DIR/scripts/version.sh")"

--- a/tests/stale-dev-bin-recovery.sh
+++ b/tests/stale-dev-bin-recovery.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -eu
+
+DIR="$(cd "$(dirname "$0")/.." && pwd)"
+tmp="$(mktemp -d)"
+trap '[ -n "${KEEP_TMP:-}" ] || rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/plugin/scripts" "$tmp/plugin/target/release" "$tmp/plugin/target/debug" "$tmp/bin"
+cp "$DIR/agenmux.tmux" "$tmp/plugin/agenmux.tmux"
+cp "$DIR/scripts/version.sh" "$tmp/plugin/scripts/version.sh"
+cp "$DIR/Cargo.toml" "$tmp/plugin/Cargo.toml"
+version="$(bash "$DIR/scripts/version.sh")"
+
+cat >"$tmp/bin/tmux" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$TEST_LOG"
+case "$*" in
+  "show-options -gq @agenmux-bin")
+    [ -f "$TEST_CLEARED" ] || printf '@agenmux-bin /removed/worktree/target/debug/agenmux\n'
+    ;;
+  "show-option -gqv @agenmux-bin")
+    [ -f "$TEST_CLEARED" ] || printf '/removed/worktree/target/debug/agenmux\n'
+    ;;
+  "set-option -gu @agenmux-bin") touch "$TEST_CLEARED" ;;
+  "wait-for -L agenmux-install"|"wait-for -U agenmux-install") ;;
+esac
+SH
+cat >"$tmp/bin/git" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+cat >"$tmp/plugin/scripts/install-bin.sh" <<SH
+#!/usr/bin/env bash
+printf 'install\n' >>"$tmp/runtime.log"
+cat >"$tmp/plugin/target/release/agenmux" <<'BIN'
+#!/usr/bin/env bash
+if [ "\${1:-}" = --version ]; then printf 'agenmux $version\n'; else printf '%s\n' "\$*" >>"$tmp/runtime.log"; fi
+BIN
+chmod +x "$tmp/plugin/target/release/agenmux"
+printf 'v$version\n-\n' >"$tmp/plugin/target/release/.agenmux-version"
+SH
+cat >"$tmp/plugin/target/debug/agenmux" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >>"$tmp/runtime.log"
+SH
+chmod +x "$tmp/plugin/target/debug/agenmux"
+chmod +x "$tmp/bin/tmux" "$tmp/bin/git" "$tmp/plugin/scripts/install-bin.sh"
+
+TEST_LOG="$tmp/tmux.log" TEST_CLEARED="$tmp/cleared" PATH="$tmp/bin:$PATH" \
+  bash "$tmp/plugin/agenmux.tmux" activate popup test-client
+
+grep -Fq 'set-option -gu @agenmux-bin' "$tmp/tmux.log"
+grep -Fq "set-option -g @agenmux-bin $tmp/plugin/target/debug/agenmux" "$tmp/tmux.log"
+! grep -qx install "$tmp/runtime.log"
+grep -qx setup "$tmp/runtime.log"
+grep -qx 'toggle popup test-client' "$tmp/runtime.log"
+echo 'ok   stale-activation-binary-recovers'
+
+rm -rf "$tmp"
+tmp="$(mktemp -d)"
+mkdir -p "$tmp/plugin/scripts" "$tmp/plugin/target/debug" "$tmp/bin"
+cp "$DIR/scripts/dev-bin.sh" "$tmp/plugin/scripts/dev-bin.sh"
+
+cat >"$tmp/bin/cargo" <<'SH'
+#!/usr/bin/env bash
+cat >"$TEST_PLUGIN/target/debug/agenmux" <<'BIN'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$TEST_RUNTIME"
+BIN
+chmod +x "$TEST_PLUGIN/target/debug/agenmux"
+SH
+cat >"$tmp/bin/tmux" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$TEST_LOG"
+case "$*" in
+  "show-options -gq @agenmux-bin") printf '@agenmux-bin /removed/worktree/target/debug/agenmux\n' ;;
+  "show-option -gqv @agenmux-bin") printf '/removed/worktree/target/debug/agenmux\n' ;;
+  "show-option -gqv @agenmux-on") printf '1\n' ;;
+esac
+SH
+chmod +x "$tmp/bin/cargo" "$tmp/bin/tmux"
+
+TEST_PLUGIN="$tmp/plugin" TEST_RUNTIME="$tmp/runtime.log" TEST_LOG="$tmp/tmux.log" \
+  PATH="$tmp/bin:$PATH" bash "$tmp/plugin/scripts/dev-bin.sh" use >/dev/null
+
+grep -qx setup "$tmp/runtime.log"
+grep -qx toggle "$tmp/runtime.log"
+grep -Fq "set-option -g @agenmux-bin $tmp/plugin/target/debug/agenmux" "$tmp/tmux.log"
+echo 'ok   stale-dev-switch-binary-recovers'


### PR DESCRIPTION
## Summary
- recover activation when `@agenmux-bin` points to a removed worktree
- let `make dev-use` switch when the previous binary no longer exists
- add regression coverage for both recovery paths
- record implementation plans under `docs/plans/`

## Verification
- `./tests/run.sh`
- `tests/stale-dev-bin-recovery.sh`
- isolated live tmux recovery opened `agenmux dev`
