### PR TITLE
Detect Pi question prompts as blocked

### DIFF
--- a/agents/pi.conf
+++ b/agents/pi.conf
@@ -3,8 +3,9 @@ AGENT_BINS="pi"
 AGENT_PATH_HINTS="pi-coding-agent"
 
 WORKING_SCREEN='^── [⠁-⣿] Working ─'
+BLOCKED_SCREEN='Enter to select.*Esc to cancel'
 
-CHECK_ORDER="ws"
+CHECK_ORDER="ws bs"
 
 TITLE_STRIP='^π - '
 

--- a/tests/fixtures/pi-blocked-2.txt
+++ b/tests/fixtures/pi-blocked-2.txt
@@ -1,0 +1,18 @@
+────────────────────────────────────────────────────────────────────────────────
+
+  Choice
+
+ Select one option.
+
+  1. First
+     Select first option.
+  2. Second
+     Select second option.
+  3. Type something.
+
+ Notes:
+────────────────────────────────────────────────────────────────────────────────
+
+────────────────────────────────────────────────────────────────────────────────
+
+ Enter to select · ↑/↓ to navigate · Esc to cancel · Ctrl+] to collapse · Shift+Enter for newline

--- a/tests/fixtures/pi-blocked.txt
+++ b/tests/fixtures/pi-blocked.txt
@@ -1,0 +1,15 @@
+────────────────────────────────────────────────────────────────────────────────
+
+  Choice
+
+ Select one option.
+
+❯ 1. First
+     Select first option.
+  2. Second
+     Select second option.
+  3. Type something.
+
+────────────────────────────────────────────────────────────────────────────────
+
+ Enter to select · ↑/↓ to navigate · n to add notes · Esc to cancel · Ctrl+] to collapse


### PR DESCRIPTION
## Summary

- detect Pi question-selection prompts as blocked
- check blocked state after the existing working indicator
- cover normal selection and notes-entry prompt variants with sanitized fixtures

## Verification

- `mise exec rust@latest -- cargo test --test parity -- fixtures_match_expected_state --exact --nocapture`
- `mise exec rust@latest -- ./tests/run.sh`
- real fresh Pi tmux pane observed through the public detector: `working → blocked → idle`
- `git diff --check`
- sanitized fixture/privacy scan
