### PR TITLE
fix(tests): wait for the cursor the key assertions depend on

### DIFF
--- a/tests/navigation.sh
+++ b/tests/navigation.sh
@@ -320,10 +320,19 @@ done
 
 # An actual agent record keeps the existing one-click direct jump. Pick a row
 # outside this window so merely leaving the work pane cannot satisfy the test.
-valid_row="$(awk -v work="$work" \
-  '$1 ~ /^%/ && $1 != work { print NR; exit }' "$tmp/agenmux-rows")"
-valid_target="$(awk -v work="$work" \
-  '$1 ~ /^%/ && $1 != work { print $1; exit }' "$tmp/agenmux-rows")"
+# The daemon rewrites the row map on its own schedule, so a read here can land
+# before the second window's agent is in it — retry rather than call that a
+# missing row.
+valid_row=''
+valid_target=''
+for _ in $(seq 1 60); do
+  valid_row="$(awk -v work="$work" \
+    '$1 ~ /^%/ && $1 != work { print NR; exit }' "$tmp/agenmux-rows")"
+  valid_target="$(awk -v work="$work" \
+    '$1 ~ /^%/ && $1 != work { print $1; exit }' "$tmp/agenmux-rows")"
+  [ -n "$valid_row" ] && [ -n "$valid_target" ] && break
+  sleep 0.05
+done
 [ -n "$valid_row" ] && [ -n "$valid_target" ] || {
   echo "FAIL navigation-key-table: no cross-window agent row"
   exit 1
@@ -414,6 +423,30 @@ for _ in $(seq 1 20); do
   printf '%s' "$control_flags" | grep -Fq control-mode && break
   sleep 0.05
 done
+# `k` is Up, and Up clamps at the top row rather than wrapping, so it can only
+# be seen to move the cursor when the cursor is below that row. The earlier
+# cross-window click puts it there: the daemon snaps the cursor onto the pane
+# the click focused. It samples focus on its own schedule instead of queueing
+# it, so wait for the snap rather than assuming it has already landed.
+cursor_snapped=0
+for _ in $(seq 1 60); do
+  cursor_row="$(tmux -S "$sock" capture-pane -p -t "$sidebar" |
+    awk '/❯/ { print NR; exit }')"
+  if [ -n "$cursor_row" ] && [ "$cursor_row" -gt 1 ]; then
+    # the row map excludes the fixed header
+    cursor_pane="$(sed -n "$((cursor_row - 1))p" "$tmp/agenmux-rows" |
+      awk '{ print $1 }')"
+    [ "$cursor_pane" = "$valid_target" ] && {
+      cursor_snapped=1
+      break
+    }
+  fi
+  sleep 0.05
+done
+[ "$cursor_snapped" -eq 1 ] || {
+  echo "FAIL navigation-key-table: cursor never reached the clicked row"
+  exit 1
+}
 picker_start="$(tmux -S "$sock" capture-pane -p -t "$sidebar" |
   sed -n '/❯/p' | head -n 1)"
 printf 'k' >&9
@@ -471,7 +504,7 @@ fi
 printf 'q' >&9
 picker_reclaimed=0
 picker_return=''
-for _ in $(seq 1 40); do
+for _ in $(seq 1 60); do
   picker_table="$(tmux -S "$sock" display-message -p -c "$client" \
     '#{client_key_table}')"
   picker_frame="$(tmux -S "$sock" capture-pane -p -t "$sidebar")"
@@ -485,7 +518,7 @@ for _ in $(seq 1 40); do
 done
 printf 'j' >&9
 second="$picker_return"
-for _ in $(seq 1 20); do
+for _ in $(seq 1 30); do
   second="$(tmux -S "$sock" capture-pane -p -t "$sidebar" |
     sed -n '/❯/p' | head -n 1)"
   [ -n "$second" ] && [ "$second" != "$picker_return" ] && break
@@ -495,7 +528,7 @@ table_after_j="$(tmux -S "$sock" display-message -p -c "$client" '#{client_key_t
 
 printf 'k' >&9
 third="$second"
-for _ in $(seq 1 20); do
+for _ in $(seq 1 30); do
   third="$(tmux -S "$sock" capture-pane -p -t "$sidebar" |
     sed -n '/❯/p' | head -n 1)"
   [ "$third" = "$picker_return" ] && break

--- a/tests/plugin.rs
+++ b/tests/plugin.rs
@@ -126,7 +126,19 @@ impl TestTmux {
 
 impl Drop for TestTmux {
     fn drop(&mut self) {
+        // kill-server leaves the socket file behind, so ask the live server
+        // where it is before taking it down. Thousands of dead sockets
+        // otherwise pile up in the shared tmux socket directory.
+        let socket_path = self.tmux(&["display-message", "-p", "#{socket_path}"]);
         let _ = self.tmux(&["kill-server"]);
+        if socket_path.status.success() {
+            let path = String::from_utf8_lossy(&socket_path.stdout)
+                .trim_end()
+                .to_string();
+            if !path.is_empty() {
+                let _ = std::fs::remove_file(path);
+            }
+        }
         let _ = std::fs::remove_dir_all(&self.tmp);
     }
 }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -285,7 +285,12 @@ esac
 exit 0
 SH
   chmod +x "$tmp/bin/tmux"
-  TMUX_STUB_LOG="$tmp/tmux.log" PATH="$tmp/bin:$PATH" bash "$DIR/agenmux.tmux"
+  # Only the key bindings are under test here. Left enabled, the eager
+  # background installer outlives this block, and the cleanup below removes the
+  # stub out from under it — its remaining tmux calls then resolve to the real
+  # binary with no server in $TMUX and land on the user's default server.
+  AGENMUX_INSTALL_REFRESH=1 TMUX_STUB_LOG="$tmp/tmux.log" \
+    PATH="$tmp/bin:$PATH" bash "$DIR/agenmux.tmux"
   if grep -q "^bind-key E run-shell -b " "$tmp/tmux.log" &&
     grep -q "^bind-key e run-shell -b " "$tmp/tmux.log" &&
     grep -Fq '/agenmux.tmux' "$tmp/tmux.log" &&


### PR DESCRIPTION
Closes #55.

## The flake

Six CI failures in six days, each on exactly one of four platforms with the other three green on the same commit. All in `navigation-key-table`.

| Run | Platform | Failure |
|---|---|---|
| 34046773254 | linux-x86_64 | pre-picker cursor did not move |
| 34031560876 | linux-aarch64 | pre-picker cursor did not move |
| 33756072356 | macos-x86_64 | pre-picker cursor did not move |
| 33737841939 | macos-aarch64 | picker not reclaimed |
| 33725966731 | linux-x86_64 | cursor did not advance |
| 33676413849 | macos-aarch64 | no cross-window agent row |

## Root cause

The test sends `k` and requires the sidebar cursor to move. `k` is Up, and Up clamps at the top row rather than wrapping, so the assertion only holds once the cursor sits below that row.

The cursor gets there because the earlier cross-window click makes the daemon snap the selection onto the pane the click focused. The daemon samples focus rather than queueing it, so under load the snap has not landed when `k` arrives, the cursor is still on the first row, and the no-op reads as a failure. The test waited on the client key table and the control-client option, never on the cursor it asserts about.

Captured at failure, cursor on the top row with the client on the sidebar:

```
DBG start=[ ❯ ⣿ codex 0.1 ...] active=[%2 agenmux]
```

Reproduced 6 of 8 runs under CPU load. A first attempt at the barrier, placed right after the click, failed immediately and showed the snap actually lands later, during the sidebar-restore window. The barrier sits there instead.

## Changes

All three are test-only. No product code.

- **`tests/navigation.sh`** waits for the cursor to reach the clicked row before the key assertions, retries the row-map read for the same reason, and widens the three daemon-dependent budgets CI showed timing out.
- **`tests/run.sh`** skips the eager background installer in the entrypoint block. It outlived the block, cleanup removed the stubbed `tmux` out from under it, and its remaining calls resolved to the real binary with no server in `$TMUX`, landing on the default server: 397 commands including `bind-key`, `set-hook -gu` and a full `agenmux setup`. On a developer machine that silently reconfigures the live tmux session. Proven by 0 leaked calls while the stub existed and 80 within 4 seconds of deleting it.
- **`tests/plugin.rs`** unlinks each test server's socket file after `kill-server`. 1340 dead sockets had accumulated in the shared tmux socket directory.

## Verification

| Check | Before | After |
|---|---|---|
| navigation.sh under CPU load | 6 of 8 failed | 6 of 6 pass |
| cargo test | — | 116 pass, 0 fail |
| tests/run.sh | — | 29 ok, rc=0 |
| default-socket calls | 397 | 3, read-only |
| `error connecting` lines per CI job | 7 | 0 |
| new socket files per run | 13 | 0 |

The 3 remaining default-socket calls are read-only `show-option` reads from the sandboxed installer. No mutations, no output. Left alone.

## Worth a reviewer's eye

The two picker-overlay variants, `picker not reclaimed` and `cursor did not advance`, never reproduced locally. The cursor barrier plausibly covers them since the whole key sequence was starting one row off, but I hedged with wider budgets rather than proving it. If they resurface, the answer is another barrier, not more seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHNWddoQoMErjYm7pntJxB
