### PR TITLE
Improve sidebar mouse navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ every two seconds.
 | Input | Action |
 | --- | --- |
 | `prefix + A` | Open the sidebar or enter navigation |
-| Click an agent row | Jump to its pane (requires `set -g mouse on`) |
-| Mouse wheel | Move selection; jump after scrolling stops |
+| Click an agent row | Select it; click the selected row again to open it (requires `set -g mouse on`) |
+| Mouse wheel | Scroll the agent list without changing selection |
 | `j` / `k`, `↑` / `↓` | Move selection |
 | `Enter` / `l` | Jump to selected agent |
 | `/` | Search agent and session names |
@@ -94,9 +94,9 @@ every two seconds.
 <summary>Search, mouse, and navigation details</summary>
 
 Clicks outside agent rows enter navigation; clicks in regular panes retain
-tmux behavior. Wheel scrolling moves one row per tick and delays the pane jump,
-so fast scrolling causes one window switch. Regular panes retain tmux
-scrollback behavior.
+tmux behavior. The first click on an agent selects it, and a second click opens
+the selected agent. Wheel scrolling moves the list viewport without changing
+selection or switching panes.
 
 During search, type normally, then press `Enter` to accept the query and restore
 `j`/`k` navigation; press `Enter` again to jump. `↑`/`↓` or
@@ -129,14 +129,13 @@ set -g status-right '#{agenmux} | %H:%M'
 | `@agenmux-height` | agent count, minimum `15` | Fixed popup height |
 | `@agenmux-hide-windows` | `agents*` | Window-picker exclusion pattern; `''` restores default picker |
 | `@agenmux-notifications` | `on` | Desktop notifications; set `off` to disable |
-| `@agenmux-wheel-jump` | `0.3` | Seconds before wheel selection jumps; `off` moves cursor only |
 
 With both keys set (e.g. `@agenmux-key 'E'`, `@agenmux-popup-key 'e'`)
 you get `prefix+E` for the split sidebar and `prefix+e` for the floating popup.
 
 In popup mode the same keybinding opens a floating window; close it with
 `q` or `Esc` inside (there is no outside toggle — the popup grabs the client).
-Click-to-jump and wheel scrolling work in split mode only (tmux does not
+Mouse clicks and wheel scrolling work in split mode only (tmux does not
 forward mouse events into a popup); keyboard jump works in both, and the popup
 reopens over the selected agent after a jump.
 

--- a/site/index.html
+++ b/site/index.html
@@ -279,7 +279,7 @@ echo "run-shell ~/.tmux/plugins/agenmux/agenmux.tmux" &gt;&gt; ~/.tmux.conf</cod
         </div>
         <div>
           <span class="k">click / wheel</span
-          ><span>jump / scroll <span class="dim">(mouse)</span></span>
+          ><span>select-open / scroll <span class="dim">(mouse)</span></span>
         </div>
       </div>
       <p>

--- a/src/input.rs
+++ b/src/input.rs
@@ -27,20 +27,25 @@ pub fn click(pane: &str, y: usize, client: &str) -> i32 {
     let target = y
         .checked_sub(1)
         .and_then(|line| {
-            std::fs::read_to_string(tmux::runtime_dir().join("agenmux-rows"))
-                .ok()?
-                .lines()
-                .nth(line)
-                .and_then(|row| row.split_whitespace().next())
-                .map(str::to_string)
+            let rows = std::fs::read_to_string(tmux::runtime_dir().join("agenmux-rows")).ok()?;
+            let mut fields = rows.lines().nth(line)?.split_whitespace();
+            let target = fields.next()?.to_string();
+            let index = fields.next()?.parse::<usize>().ok()?;
+            let selected = fields.next() == Some("1");
+            Some((target, index, selected))
         })
-        .filter(|target| target.starts_with('%') && panes.iter().any(|id| id == target));
+        .filter(|(target, _, _)| target.starts_with('%') && panes.iter().any(|id| id == target));
 
-    if let Some(target) = target {
-        let _ = sidebar::send_key("all");
-        let _ = tmux::command_status(&["switch-client", "-c", client, "-t", &target]);
-        let _ = tmux::command_status(&["select-window", "-t", &target]);
-        let _ = tmux::command_status(&["select-pane", "-t", &target]);
+    if let Some((target, index, selected)) = target {
+        if selected {
+            let _ = sidebar::send_key("all");
+            let _ = tmux::command_status(&["switch-client", "-c", client, "-t", &target]);
+            let _ = tmux::command_status(&["select-window", "-t", &target]);
+            let _ = tmux::command_status(&["select-pane", "-t", &target]);
+        } else if tmux::command_status(&["switch-client", "-c", client, "-t", pane]).is_ok() {
+            let _ = tmux::command_status(&["switch-client", "-c", client, "-T", "agenmux"]);
+            let _ = sidebar::select(index);
+        }
     } else if tmux::command_status(&["switch-client", "-c", client, "-t", pane]).is_ok() {
         let _ = tmux::command_status(&["switch-client", "-c", client, "-T", "agenmux"]);
     }

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -192,6 +192,7 @@ impl StateFilter {
 
 enum Key {
     Up,
+    Select(usize),
     Down,
     WheelUp,
     WheelDown,
@@ -247,6 +248,19 @@ fn read_key(fd: libc::c_int) -> Key {
         b'k' => Key::Up,
         0x01 => Key::WheelUp,
         0x02 => Key::WheelDown,
+        0x05 => {
+            let mut index = [0u8; 4];
+            for byte in &mut index {
+                let Some(next) = poll_fd(fd, Some(Duration::from_millis(50)))
+                    .then(|| read_byte(fd))
+                    .flatten()
+                else {
+                    return Key::Other;
+                };
+                *byte = next;
+            }
+            Key::Select(u32::from_be_bytes(index) as usize)
+        }
         b'q' | 0x03 | 0x04 => Key::Quit, // q, Ctrl-C, Ctrl-D
         b'Q' => Key::Close,
         b'l' | b'\r' | b'\n' => Key::Jump,
@@ -362,6 +376,19 @@ pub fn send_key(name: &str) -> i32 {
             _ => return 2,
         }
     };
+    send_bytes(&bytes)
+}
+
+pub fn select(index: usize) -> i32 {
+    let Ok(index) = u32::try_from(index) else {
+        return 2;
+    };
+    let mut bytes = vec![0x05];
+    bytes.extend(index.to_be_bytes());
+    send_bytes(&bytes)
+}
+
+fn send_bytes(bytes: &[u8]) -> i32 {
     let path = crate::tmux::runtime_dir().join("agenmux-keys");
     let Ok(c) = std::ffi::CString::new(path.as_os_str().as_encoded_bytes()) else {
         return 1;
@@ -580,18 +607,6 @@ fn superseded(mine: &str, current: &str) -> bool {
     !mine.is_empty() && !current.is_empty() && current != mine
 }
 
-fn parse_wheel_delay(value: &str) -> Option<Duration> {
-    match value.trim() {
-        "off" => None,
-        "" => Some(Duration::from_millis(300)),
-        value => value
-            .parse::<f64>()
-            .ok()
-            .filter(|seconds| seconds.is_finite() && *seconds >= 0.0)
-            .and_then(|seconds| Duration::try_from_secs_f64(seconds).ok()),
-    }
-}
-
 /// Headless-mode state: frames → visible panes, keys ← FIFO, size ← panes.
 struct Daemon {
     keys_path: PathBuf,
@@ -625,7 +640,8 @@ pub struct Sidebar {
     state_filter: Option<StateFilter>,
     search_focused: bool,
     sel: usize,    // 1-based index into visible, like the bash script
-    scroll: usize, // first visible list line — follows the selection
+    scroll: usize, // first visible list line
+    follow_selection: bool,
     sel_pane: String,
     last_active: String,
     active: String,
@@ -672,6 +688,7 @@ fn new_sidebar(
         sel: 1,
         scroll: 0,
         sel_pane: String::new(),
+        follow_selection: true,
         last_active: String::new(),
         active: String::new(),
         active_session: String::new(),
@@ -836,22 +853,11 @@ fn event_loop(sb: &mut Sidebar) -> bool {
     let key_fd = sb.daemon.as_ref().map_or(0, |d| d.keys_fd);
     let mut next_scan = Instant::now(); // scan immediately
     let mut next_tick = Instant::now();
-    let mut wheel_jump_at: Option<Instant> = None;
     loop {
         if QUIT.load(Ordering::Relaxed) {
             break;
         }
         let mut now = Instant::now();
-        if wheel_jump_at.is_some_and(|deadline| now >= deadline) {
-            wheel_jump_at = None;
-            match sb.dispatch_key(Key::Jump) {
-                DispatchResult::Continue => {}
-                DispatchResult::Break => break,
-                DispatchResult::QuietExit => return true,
-            }
-            sb.render(false);
-            now = Instant::now();
-        }
         if now >= next_scan {
             match sb.scan_tick() {
                 Ok(()) => {}
@@ -887,14 +893,11 @@ fn event_loop(sb: &mut Sidebar) -> bool {
             sb.render(false);
         }
         // animated states need ticks; all-idle sleeps until the next scan
-        let mut wake = if animating {
+        let wake = if animating {
             next_tick.saturating_duration_since(now)
         } else {
             next_scan.saturating_duration_since(now)
         };
-        if let Some(deadline) = wheel_jump_at {
-            wake = wake.min(deadline.saturating_duration_since(now));
-        }
         let (key_ready, pipe_ready) = poll_inputs(key_fd, sb.tmux.fd(), sb.tmux.buffered(), wake);
         if pipe_ready {
             // focus notification (%window-pane-changed etc.) — rescan now so
@@ -911,16 +914,6 @@ fn event_loop(sb: &mut Sidebar) -> bool {
             } else {
                 read_key(key_fd)
             };
-            let (key, wheel) = match key {
-                Key::WheelUp => (Key::Up, true),
-                Key::WheelDown => (Key::Down, true),
-                key => (key, false),
-            };
-            if wheel {
-                wheel_jump_at = sb
-                    .wheel_jump_delay()
-                    .and_then(|delay| Instant::now().checked_add(delay));
-            }
             match sb.dispatch_key(key) {
                 DispatchResult::Continue => {}
                 DispatchResult::Break => break,
@@ -949,10 +942,17 @@ fn cleanup(rows_file: &PathBuf, pin: &Option<String>) {
 }
 
 impl Sidebar {
-    /// Route every logical key through the active UI mode. Delayed wheel jumps
-    /// use this too, so search accepts before jumping and overlays consume the
-    /// key instead of acting on the hidden list.
+    /// Route every logical key through the active UI mode. Mouse selection is
+    /// handled before mode dispatch; overlays clear their row map, so they cannot
+    /// receive a stale click on the hidden list.
     fn dispatch_key(&mut self, key: Key) -> DispatchResult {
+        if let Key::Select(index) = &key {
+            self.sel = (*index).max(1);
+            self.follow_selection = true;
+            self.clamp_sel();
+            self.sync_sel_pane();
+            return DispatchResult::Continue;
+        }
         match dispatch_mode(self.overlay.as_ref(), self.search_focused) {
             DispatchMode::Overlay => {
                 self.overlay_key(key);
@@ -967,6 +967,8 @@ impl Sidebar {
         match key {
             Key::Down => self.move_sel(1),
             Key::Up => self.move_sel(-1),
+            Key::WheelUp => self.scroll_viewport(-1),
+            Key::WheelDown => self.scroll_viewport(1),
             Key::Jump => {
                 if self.jump() {
                     return DispatchResult::Break;
@@ -998,23 +1000,9 @@ impl Sidebar {
                 }
                 return DispatchResult::Break;
             }
-            Key::Backspace
-            | Key::ClearSearch
-            | Key::Text(_)
-            | Key::WheelUp
-            | Key::WheelDown
-            | Key::Other => {}
+            Key::Backspace | Key::ClearSearch | Key::Text(_) | Key::Select(_) | Key::Other => {}
         }
         DispatchResult::Continue
-    }
-
-    fn wheel_jump_delay(&mut self) -> Option<Duration> {
-        parse_wheel_delay(
-            &self
-                .tmux
-                .run("show-option -gqv @agenmux-wheel-jump")
-                .unwrap_or_default(),
-        )
     }
 
     fn scan_tick(&mut self) -> Result<(), TmuxError> {
@@ -1069,6 +1057,7 @@ impl Sidebar {
                 .position(|&i| self.rows[i].pane == self.active)
             {
                 self.sel = i + 1;
+                self.follow_selection = true;
                 self.sel_pane = self.active.clone();
             }
             self.last_active = self.active.clone();
@@ -1095,8 +1084,14 @@ impl Sidebar {
 
     fn move_sel(&mut self, d: i64) {
         self.sel = (self.sel as i64 + d).max(1) as usize;
+        self.follow_selection = true;
         self.clamp_sel();
         self.sync_sel_pane();
+    }
+
+    fn scroll_viewport(&mut self, d: i64) {
+        self.scroll = (self.scroll as i64 + d).max(0) as usize;
+        self.follow_selection = false;
     }
 
     fn clamp_sel(&mut self) {
@@ -1141,6 +1136,7 @@ impl Sidebar {
         self.visible = filtered_indices(&self.rows, &self.query, self.state_filter);
         if select_first {
             self.sel = 1;
+            self.follow_selection = true;
             self.sync_sel_pane();
         } else {
             self.clamp_sel();
@@ -1149,7 +1145,6 @@ impl Sidebar {
         if self.visible.is_empty() {
             self.sel_pane.clear();
         }
-        self.scroll = 0;
     }
 
     fn focus_search(&mut self) {
@@ -1197,9 +1192,10 @@ impl Sidebar {
                     .extend(text.chars().filter(|c| !c.is_control()).take(room));
                 self.rebuild_visible(true);
             }
+            Key::WheelUp => self.scroll_viewport(-1),
+            Key::WheelDown => self.scroll_viewport(1),
             Key::AllStates => self.clear_filter(),
-            Key::WheelUp
-            | Key::WheelDown
+            Key::Select(_)
             | Key::Search
             | Key::CycleState
             | Key::Help
@@ -1636,7 +1632,7 @@ impl Sidebar {
             frame.push_str(&format!("{E}[2mno matches · Esc shows all{E}[0m{E}[K\n"));
         } else {
             // build filtered agents plus their session context, then window it
-            let mut lines: Vec<(String, &str)> = Vec::new(); // (text, vis pane)
+            let mut lines: Vec<(String, &str, usize, bool)> = Vec::new();
             let (mut sel_top, mut sel_bot) = (0usize, 0usize);
             let mut session = "";
             for (n, &row_i) in self.visible.iter().enumerate() {
@@ -1647,7 +1643,12 @@ impl Sidebar {
                     // clip to pane width — a wrapped header shifts every row
                     // below it and breaks the click→rows-file mapping
                     let sess_clipped: String = sess.chars().take(cols).collect();
-                    lines.push((format!("{E}[1;34m{sess_clipped}{E}[0m{E}[K\n"), "-"));
+                    lines.push((
+                        format!("{E}[1;34m{sess_clipped}{E}[0m{E}[K\n"),
+                        "-",
+                        0,
+                        false,
+                    ));
                 }
                 if Some(n) == cursor {
                     sel_top = lines.len();
@@ -1672,6 +1673,8 @@ impl Sidebar {
                 lines.push((
                     format!("{}{E}[K\n", bar(&row, row_bg, cols, width)),
                     &r.pane,
+                    n + 1,
+                    selected,
                 ));
                 if !r.title.is_empty() {
                     let t: String = r.title.chars().take(cols.saturating_sub(5)).collect();
@@ -1680,6 +1683,8 @@ impl Sidebar {
                     lines.push((
                         format!("{}{E}[K\n", bar(&line, row_bg, cols, width)),
                         &r.pane,
+                        n + 1,
+                        selected,
                     ));
                 }
                 if Some(n) == cursor {
@@ -1687,7 +1692,7 @@ impl Sidebar {
                 }
             }
             // cursor's session header gives context — drag it into view
-            if cursor.is_some() {
+            if self.follow_selection && cursor.is_some() {
                 if sel_top > 0 && lines[sel_top - 1].1 == "-" {
                     sel_top -= 1;
                 }
@@ -1700,16 +1705,45 @@ impl Sidebar {
                     }
                 }
             }
+            self.follow_selection = false;
             if space > 0 {
                 self.scroll = self.scroll.min(lines.len().saturating_sub(space));
             } else {
                 self.scroll = 0;
             }
             let end = (self.scroll + space).min(lines.len());
-            for (text, pane) in &lines[self.scroll..end] {
-                frame.push_str(text);
-                vis.push_str(pane);
-                vis.push('\n');
+            let overflow = lines.len() > space && space > 0 && cols > 0;
+            let thumb_len = if overflow {
+                space
+                    .saturating_mul(space)
+                    .checked_div(lines.len())
+                    .unwrap_or(1)
+                    .max(1)
+            } else {
+                0
+            };
+            let thumb_start = if overflow {
+                self.scroll.saturating_mul(space - thumb_len) / lines.len().saturating_sub(space)
+            } else {
+                0
+            };
+            for (row, (text, pane, index, selected)) in lines[self.scroll..end].iter().enumerate() {
+                if overflow {
+                    frame.push_str(text.trim_end_matches('\n'));
+                    let glyph = if (thumb_start..thumb_start + thumb_len).contains(&row) {
+                        '▐'
+                    } else {
+                        '│'
+                    };
+                    frame.push_str(&format!("{E}[{cols}G{E}[2m{glyph}{E}[0m\n"));
+                } else {
+                    frame.push_str(text);
+                }
+                if *pane == "-" {
+                    vis.push_str("-\n");
+                } else {
+                    vis.push_str(&format!("{pane}\t{index}\t{}\n", usize::from(*selected)));
+                }
             }
         }
         frame.push_str(&format!("{E}[J"));
@@ -2010,17 +2044,7 @@ mod tests {
     }
 
     #[test]
-    fn wheel_jump_delay_preserves_option_contract() {
-        assert_eq!(parse_wheel_delay(""), Some(Duration::from_millis(300)));
-        assert_eq!(parse_wheel_delay("0.5"), Some(Duration::from_millis(500)));
-        assert_eq!(parse_wheel_delay("0"), Some(Duration::ZERO));
-        assert_eq!(parse_wheel_delay("off"), None);
-        assert_eq!(parse_wheel_delay("-1"), None);
-        assert_eq!(parse_wheel_delay("invalid"), None);
-    }
-
-    #[test]
-    fn delayed_wheel_jump_uses_search_help_and_versions_routes() {
+    fn input_modes_route_search_help_and_versions() {
         assert_eq!(dispatch_mode(None, true), DispatchMode::Search);
         assert_eq!(
             dispatch_mode(Some(&Overlay::Help), false),

--- a/tests/navigation.sh
+++ b/tests/navigation.sh
@@ -390,18 +390,40 @@ if [ -n "$valid_row" ] && [ -n "$valid_target" ]; then
   tmux -S "$sock" select-pane -t "$work"
   env TMPDIR="$tmp" TMUX="$sock,$server_pid,0" \
     "$BIN" click "$sidebar" "$valid_row" "$client"
-  for _ in $(seq 1 20); do
+  first_click_selects=0
+  for _ in $(seq 1 40); do
     valid_click_table="$(tmux -S "$sock" display-message -p -c "$client" \
       '#{client_key_table}')"
     valid_click_focus="$(tmux -S "$sock" display-message -p -c "$client" \
       '#{pane_id}')"
-    if [ "$valid_click_table" = root ] &&
-      [ "$valid_click_focus" = "$valid_target" ]; then
-      valid_click_works=1
+    selected_row="$(awk -v target="$valid_target" '$1 == target { print NR; exit }' \
+      "$tmp/agenmux-rows")"
+    cursor_row="$(tmux -S "$sock" capture-pane -p -t "$sidebar" |
+      awk '/❯/ { print NR - 1; exit }')"
+    if [ "$valid_click_table" = agenmux ] &&
+      [ "$valid_click_focus" = "$sidebar" ] &&
+      [ -n "$selected_row" ] && [ "$cursor_row" = "$selected_row" ]; then
+      first_click_selects=1
       break
     fi
     sleep 0.05
   done
+  if [ "$first_click_selects" -eq 1 ]; then
+    env TMPDIR="$tmp" TMUX="$sock,$server_pid,0" \
+      "$BIN" click "$sidebar" "$selected_row" "$client"
+    for _ in $(seq 1 20); do
+      valid_click_table="$(tmux -S "$sock" display-message -p -c "$client" \
+        '#{client_key_table}')"
+      valid_click_focus="$(tmux -S "$sock" display-message -p -c "$client" \
+        '#{pane_id}')"
+      if [ "$valid_click_table" = root ] &&
+        [ "$valid_click_focus" = "$valid_target" ]; then
+        valid_click_works=1
+        break
+      fi
+      sleep 0.05
+    done
+  fi
 fi
 
 # Restore the sidebar as the interaction target for the keyboard checks below.
@@ -535,32 +557,9 @@ for _ in $(seq 1 30); do
   sleep 0.1
 done
 
-# Preserved-pane mode: the pane has no stdin, so the handler must reach the
-# daemon through its key FIFO. Settle-jump off — cursor movement alone here.
-tmux -S "$sock" set-option -g @agenmux-wheel-jump off
-env TMPDIR="$tmp" TMUX="$sock,$server_pid,0" \
-  "$BIN" wheel "$sidebar" down
-wheel_down="$third"
-for _ in $(seq 1 20); do
-  wheel_down="$(tmux -S "$sock" capture-pane -p -t "$sidebar" |
-    sed -n '/❯/p' | head -n 1)"
-  [ -n "$wheel_down" ] && [ "$wheel_down" != "$third" ] && break
-  sleep 0.1
-done
-env TMPDIR="$tmp" TMUX="$sock,$server_pid,0" \
-  "$BIN" wheel "$sidebar" up
-wheel_up="$wheel_down"
-for _ in $(seq 1 20); do
-  wheel_up="$(tmux -S "$sock" capture-pane -p -t "$sidebar" |
-    sed -n '/❯/p' | head -n 1)"
-  [ "$wheel_up" = "$third" ] && break
-  sleep 0.1
-done
-
-# Rapid native wheel ticks overwrite one settle deadline. After the one jump,
-# returning to the sidebar must stay there—no older timer may fire later.
-# Leave one real client so the daemon's established newest-client jump policy
-# has one deterministic recipient.
+# Wheel input scrolls an overflowing viewport without moving selection or
+# opening an agent. Add temporary agent windows, then remove them before the
+# search assertions below.
 kill "$secondary_pid" 2>/dev/null || true
 wait "$secondary_pid" 2>/dev/null || true
 secondary_pid=''
@@ -570,54 +569,69 @@ for _ in $(seq 1 20); do
   [ "$real_clients" -eq 1 ] && break
   sleep 0.05
 done
-tmux -S "$sock" set-option -g @agenmux-wheel-jump 0.5
-wheel_client="$(tmux -S "$sock" list-clients \
-  -f '#{?#{m:*control-mode*,#{client_flags}},0,1}' \
-  -F '#{client_activity} #{client_name}' | sort -n | tail -n 1 | cut -d' ' -f2-)"
-env TMPDIR="$tmp" TMUX="$sock,$server_pid,0" "$BIN" wheel "$sidebar" down
-sleep 0.05
-env TMPDIR="$tmp" TMUX="$sock,$server_pid,0" "$BIN" wheel "$sidebar" up
-sleep 0.05
-env TMPDIR="$tmp" TMUX="$sock,$server_pid,0" "$BIN" wheel "$sidebar" down
-wheel_delay_target=''
+for i in $(seq 1 40); do
+  tmux -S "$sock" new-window -d -t navigation: -n "overflow-$i" "$tmp/codex"
+done
+for _ in $(seq 1 80); do
+  overflow_agents="$(awk '$1 ~ /^%/ { seen[$1]=1 } END { print length(seen) }' \
+    "$tmp/agenmux-scan-cache")"
+  [ "$overflow_agents" -gt 32 ] && break
+  sleep 0.1
+done
+scrollbar_frame="$(tmux -S "$sock" capture-pane -p -t "$sidebar")"
+scrollbar_works=0
+if printf '%s\n' "$scrollbar_frame" | grep -Fq '▐'; then
+  scrollbar_works=1
+fi
 for _ in $(seq 1 20); do
-  custom_cursor="$(tmux -S "$sock" capture-pane -p -t "$sidebar" |
+  wheel_up="$(tmux -S "$sock" capture-pane -p -t "$sidebar" |
     sed -n '/❯/p' | head -n 1)"
-  if [ -n "$custom_cursor" ] && [ "$custom_cursor" != "$third" ]; then
-    cursor_row="$(tmux -S "$sock" capture-pane -p -t "$sidebar" |
-      awk '/❯/ { print NR; exit }')"
-    if [ -n "$cursor_row" ] && [ "$cursor_row" -gt 1 ]; then
-      map_row=$((cursor_row - 1)) # row map excludes the fixed header
-      wheel_delay_target="$(sed -n "${map_row}p" "$tmp/agenmux-rows" |
-        awk '{ print $1 }')"
-    fi
-  fi
-  case "$wheel_delay_target" in %*) break ;; esac
+  [ -n "$wheel_up" ] && break
   sleep 0.05
 done
-wheel_delay_jumped=0
-case "$wheel_delay_target" in
-%*)
-  for _ in $(seq 1 30); do
-    delay_focus="$(tmux -S "$sock" display-message -p -c "$wheel_client" '#{pane_id}')"
-    [ "$delay_focus" = "$wheel_delay_target" ] &&
-      {
-        wheel_delay_jumped=1
-        break
-      }
-    sleep 0.05
-  done
-  ;;
-esac
+wheel_selected="$wheel_up"
+wheel_top_before="$(sed -n '1p' "$tmp/agenmux-rows")"
+tmux -S "$sock" set-option -g @agenmux-wheel-jump 0.05
+env TMPDIR="$tmp" TMUX="$sock,$server_pid,0" \
+  "$BIN" wheel "$sidebar" down
+wheel_top_after="$wheel_top_before"
+for _ in $(seq 1 20); do
+  wheel_top_after="$(sed -n '1p' "$tmp/agenmux-rows")"
+  [ "$wheel_top_after" != "$wheel_top_before" ] && break
+  sleep 0.05
+done
+sleep 0.15
+wheel_down="$(tmux -S "$sock" capture-pane -p -t "$sidebar" |
+  sed -n '/❯/p' | head -n 1)"
+wheel_focus="$(tmux -S "$sock" display-message -p -c "$client" '#{pane_id}')"
+env TMPDIR="$tmp" TMUX="$sock,$server_pid,0" \
+  "$BIN" wheel "$sidebar" up
+for _ in $(seq 1 20); do
+  wheel_top_restored="$(sed -n '1p' "$tmp/agenmux-rows")"
+  wheel_up="$(tmux -S "$sock" capture-pane -p -t "$sidebar" |
+    sed -n '/❯/p' | head -n 1)"
+  [ "$wheel_top_restored" = "$wheel_top_before" ] &&
+    [ "$wheel_up" = "$wheel_selected" ] && break
+  sleep 0.05
+done
 wheel_delay_works=0
-if [ "$wheel_delay_jumped" -eq 1 ]; then
-  tmux -S "$sock" switch-client -c "$wheel_client" -t "$sidebar"
-  tmux -S "$sock" switch-client -c "$wheel_client" -T agenmux
-  sleep 0.65
-  delay_focus="$(tmux -S "$sock" display-message -p -c "$wheel_client" '#{pane_id}')"
-  [ "$delay_focus" = "$sidebar" ] && wheel_delay_works=1
+if [ "$overflow_agents" -gt 32 ] &&
+  [ "$wheel_top_after" != "$wheel_top_before" ] &&
+  [ "$wheel_down" = "$wheel_selected" ] && [ "$wheel_focus" = "$sidebar" ] &&
+  [ "$wheel_top_restored" = "$wheel_top_before" ] &&
+  [ "$wheel_up" = "$wheel_selected" ]; then
+  wheel_delay_works=1
 fi
-tmux -S "$sock" set-option -g @agenmux-wheel-jump off
+tmux -S "$sock" set-option -gu @agenmux-wheel-jump
+tmux -S "$sock" list-windows -t navigation -F '#{window_id}	#{window_name}' |
+  awk -F '\t' '$2 ~ /^overflow-/ { print $1 }' |
+  while IFS= read -r window; do tmux -S "$sock" kill-window -t "$window"; done
+for _ in $(seq 1 80); do
+  remaining_agents="$(awk '$1 ~ /^%/ { seen[$1]=1 } END { print length(seen) }' \
+    "$tmp/agenmux-rows")"
+  [ "$remaining_agents" -eq 2 ] && break
+  sleep 0.1
+done
 
 # Simulate leaving through an agent jump, then restoring the exact client's
 # processless-sidebar focus and navigation table.
@@ -908,8 +922,10 @@ if [ "$table" = agenmux ] && [ "$initial_focus" = agenmux ] &&
   [ "$table_after_j" = agenmux ] &&
   printf '%s' "$control_flags" | grep -Fq control-mode &&
   [ "$second" != "$picker_return" ] && [ "$third" = "$picker_return" ] &&
-  [ "$wheel_down" != "$third" ] && [ "$wheel_up" = "$third" ] &&
+  [ "$wheel_down" = "$wheel_selected" ] &&
+  [ "$wheel_up" = "$wheel_selected" ] &&
   [ "$wheel_delay_works" -eq 1 ] &&
+  [ "$scrollbar_works" -eq 1 ] &&
   [ "$return_table" = agenmux ] && [ "$return_focus" = agenmux ] &&
   [ "$fourth" != "$third" ] && [ "$search_works" -eq 1 ] &&
   [ "$search_accept_works" -eq 1 ] && [ "$search_jk_works" -eq 1 ] &&
@@ -924,6 +940,6 @@ if [ "$table" = agenmux ] && [ "$initial_focus" = agenmux ] &&
   [ "$notification_stale_noop" -eq 1 ]; then
   echo "ok   attached-client-jk-navigation"
 else
-  echo "FAIL navigation-key-table: table=$table initial-focus=[$initial_focus] initial-hint=[$inactive_hint_hidden/$initial_hint] chooser=[$chooser_open_unzoomed/$chooser_state/$chooser_width] ctrl-l=[$ctrl_l_works/$ctrl_l_table/$ctrl_l_focus] missing-client=[$missing_client_noop/$missing_client_table/$missing_secondary_table/$missing_client_focus] empty-click=[$empty_click_works/$empty_click_table/$secondary_click_table/$empty_click_focus/green=$empty_click_green] stale-click=[$stale_click_works/$stale_click_table/$stale_click_focus] non-agent=[$non_agent_locations_work/$location_table/$location_focus] agent-missing-client=[$agent_missing_client_noop/$agent_missing_primary_table/$agent_missing_secondary_table/$agent_missing_focus] vanished-sidebar=[$vanished_sidebar_noop/$vanished_sidebar_table/$vanished_sidebar_focus] valid-click=[$valid_click_works/$valid_click_table/$valid_click_focus/$valid_target] picker=[$picker_open/click=$picker_click_works/$picker_click_table/$picker_click_focus/rows=$picker_click_rows/frame=$picker_click_first/$picker_reclaimed/$picker_table/$picker_before/$picker_return] after-j=$table_after_j control=[$control/$control_flags] first=[$first] second=[$second] third=[$third] wheel=[$wheel_down/$wheel_up/delay=$wheel_delay_works/target=$wheel_delay_target] return=[$return_table/$return_focus] fourth=[$fourth] search=[$search_works/$search_targets/$search_table/$search_frame/$search_hint/accept=$search_accept_works/$accept_table/$accept_frame/$accept_hint/jk=$search_jk_works/$accepted_cursor/$filtered_cursor/blur=$search_blur_works/$blur_table/$blur_targets] filters=[$blocked_filter_works/$blocked_targets/$blocked_frame/$blocked_hint/$working_filter_works/$working_targets/$working_frame/$idle_filter_works/$idle_targets/$idle_frame/$all_filter_works/$all_targets/$all_frame] q-leave=[$q_left/$exit_table/$exit_focus] escape=[$escape_ready/$escape_reset/$escape_left/$escape_table/$escape_focus/$escape_frame] Q-close=[$close_ready/$q_closed/$close_table] notification-open=[$notification_open_works/$notification_stale_noop/$notification_client]"
+  echo "FAIL navigation-key-table: table=$table initial-focus=[$initial_focus] initial-hint=[$inactive_hint_hidden/$initial_hint] chooser=[$chooser_open_unzoomed/$chooser_state/$chooser_width] ctrl-l=[$ctrl_l_works/$ctrl_l_table/$ctrl_l_focus] missing-client=[$missing_client_noop/$missing_client_table/$missing_secondary_table/$missing_client_focus] empty-click=[$empty_click_works/$empty_click_table/$secondary_click_table/$empty_click_focus/green=$empty_click_green] stale-click=[$stale_click_works/$stale_click_table/$stale_click_focus] non-agent=[$non_agent_locations_work/$location_table/$location_focus] agent-missing-client=[$agent_missing_client_noop/$agent_missing_primary_table/$agent_missing_secondary_table/$agent_missing_focus] vanished-sidebar=[$vanished_sidebar_noop/$vanished_sidebar_table/$vanished_sidebar_focus] valid-click=[$valid_click_works/$valid_click_table/$valid_click_focus/$valid_target] picker=[$picker_open/click=$picker_click_works/$picker_click_table/$picker_click_focus/rows=$picker_click_rows/frame=$picker_click_first/$picker_reclaimed/$picker_table/$picker_before/$picker_return] after-j=$table_after_j control=[$control/$control_flags] first=[$first] second=[$second] third=[$third] wheel=[$wheel_down/$wheel_up/scroll=$wheel_delay_works/top=$wheel_top_before->$wheel_top_after->$wheel_top_restored/focus=$wheel_focus] return=[$return_table/$return_focus] fourth=[$fourth] search=[$search_works/$search_targets/$search_table/$search_frame/$search_hint/accept=$search_accept_works/$accept_table/$accept_frame/$accept_hint/jk=$search_jk_works/$accepted_cursor/$filtered_cursor/blur=$search_blur_works/$blur_table/$blur_targets] filters=[$blocked_filter_works/$blocked_targets/$blocked_frame/$blocked_hint/$working_filter_works/$working_targets/$working_frame/$idle_filter_works/$idle_targets/$idle_frame/$all_filter_works/$all_targets/$all_frame] q-leave=[$q_left/$exit_table/$exit_focus] escape=[$escape_ready/$escape_reset/$escape_left/$escape_table/$escape_focus/$escape_frame] Q-close=[$close_ready/$q_closed/$close_table] notification-open=[$notification_open_works/$notification_stale_noop/$notification_client]"
   exit 1
 fi


### PR DESCRIPTION
## Summary

- make sidebar clicks select an agent before opening it on a second click
- scroll overflowing agent lists without moving selection or switching panes
- render a proportional half-block scrollbar while preserving regular-pane mouse behavior
- update navigation documentation

Closes #58

## Testing

- `mise exec rust@latest -- cargo test`
- `mise exec rust@latest -- cargo build --release`
- `AGENMUX_BIN="$PWD/target/release/agenmux" bash tests/navigation.sh`
- `git diff --check`

## Known test-suite issue

`tests/run.sh` reached the pre-existing `mirror-mode-no-bump-lifecycle` check: one run reported `left=2`, and a retry hung in that check's concurrent `pane-add` wait. The focused navigation integration and all Rust tests pass.
