### PR TITLE
Add timed gg/G agent navigation

### DIFF
--- a/src/setup.rs
+++ b/src/setup.rs
@@ -69,7 +69,7 @@ fn setup(plugin_dir: &Path) -> Result<(), TmuxError> {
     install_wheel_keys(&bin)?;
     install_picker_filter()?;
     install_status(&bin)?;
-    tmux::command_status(&["set-option", "-g", "@agenmux-nav-version", "12"])
+    tmux::command_status(&["set-option", "-g", "@agenmux-nav-version", "13"])
 }
 
 fn clear_legacy_options_and_hooks() -> Result<(), TmuxError> {
@@ -179,6 +179,8 @@ fn key_command(bin: &str, action: &str, next: &str, background: bool) -> String 
 
 fn install_normal_keys(bin: &str) -> Result<(), TmuxError> {
     for (key, action, next) in [
+        ("G", "last", NORMAL_TABLE),
+        ("g", "sequence-67", NORMAL_TABLE),
         ("j", "j", NORMAL_TABLE),
         ("k", "k", NORMAL_TABLE),
         ("Down", "down", NORMAL_TABLE),

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -25,6 +25,7 @@ use std::time::{Duration, Instant};
 static WINCH: AtomicBool = AtomicBool::new(false);
 static QUIT: AtomicBool = AtomicBool::new(false);
 
+const KEY_SEQUENCE_TIMEOUT: Duration = Duration::from_secs(1);
 extern "C" fn on_winch(_: libc::c_int) {
     WINCH.store(true, Ordering::Relaxed);
 }
@@ -190,7 +191,11 @@ impl StateFilter {
     }
 }
 
+#[derive(Clone)]
 enum Key {
+    First,
+    Last,
+    Sequence(char),
     Up,
     Select(usize),
     Down,
@@ -208,6 +213,52 @@ enum Key {
     AllStates,
     Text(String),
     Other,
+}
+
+#[derive(Default)]
+struct KeySequence {
+    pending: String,
+    last: Option<Instant>,
+}
+
+enum SequenceResult {
+    Pending,
+    Match(Key),
+    Miss,
+}
+
+impl KeySequence {
+    fn push(&mut self, key: char, now: Instant, bindings: &[(&str, Key)]) -> SequenceResult {
+        if self
+            .last
+            .is_some_and(|last| now.duration_since(last) > KEY_SEQUENCE_TIMEOUT)
+        {
+            self.clear();
+        }
+        self.pending.push(key);
+        self.last = Some(now);
+        if let Some((_, action)) = bindings
+            .iter()
+            .find(|(sequence, _)| *sequence == self.pending)
+        {
+            let action = action.clone();
+            self.clear();
+            SequenceResult::Match(action)
+        } else if bindings
+            .iter()
+            .any(|(sequence, _)| sequence.starts_with(&self.pending))
+        {
+            SequenceResult::Pending
+        } else {
+            self.clear();
+            SequenceResult::Miss
+        }
+    }
+
+    fn clear(&mut self) {
+        self.pending.clear();
+        self.last = None;
+    }
 }
 
 enum Overlay {
@@ -244,6 +295,14 @@ fn read_key(fd: libc::c_int) -> Key {
         return Key::Quit;
     }; // EOF: explicit close
     match b {
+        b'G' => Key::Last,
+        b'g' => Key::Sequence('g'),
+        0x06 => poll_fd(fd, Some(Duration::from_millis(50)))
+            .then(|| read_byte(fd))
+            .flatten()
+            .filter(|b| (0x20..=0x7e).contains(b))
+            .map(|b| Key::Sequence(char::from(b)))
+            .unwrap_or(Key::Other),
         b'j' => Key::Down,
         b'k' => Key::Up,
         0x01 => Key::WheelUp,
@@ -352,8 +411,17 @@ pub fn send_key(name: &str) -> i32 {
             return 2;
         }
         vec![0, byte]
+    } else if let Some(hex) = name.strip_prefix("sequence-") {
+        let Ok(byte) = u8::from_str_radix(hex, 16) else {
+            return 2;
+        };
+        if !(0x20..=0x7e).contains(&byte) {
+            return 2;
+        }
+        vec![0x06, byte]
     } else {
         match name {
+            "last" => b"G".to_vec(),
             "up" => b"\x1b[A".to_vec(),
             "down" => b"\x1b[B".to_vec(),
             "enter" => b"\r".to_vec(),
@@ -639,6 +707,7 @@ pub struct Sidebar {
     query: String,
     state_filter: Option<StateFilter>,
     search_focused: bool,
+    key_sequence: KeySequence,
     sel: usize,    // 1-based index into visible, like the bash script
     scroll: usize, // first visible list line
     follow_selection: bool,
@@ -685,6 +754,7 @@ fn new_sidebar(
         query: String::new(),
         state_filter: None,
         search_focused: false,
+        key_sequence: KeySequence::default(),
         sel: 1,
         scroll: 0,
         sel_pane: String::new(),
@@ -946,11 +1016,18 @@ impl Sidebar {
     /// handled before mode dispatch; overlays clear their row map, so they cannot
     /// receive a stale click on the hidden list.
     fn dispatch_key(&mut self, key: Key) -> DispatchResult {
+        if let Key::Sequence(key) = key {
+            return match self
+                .key_sequence
+                .push(key, Instant::now(), &[("gg", Key::First)])
+            {
+                SequenceResult::Match(action) => self.dispatch_key(action),
+                SequenceResult::Pending | SequenceResult::Miss => DispatchResult::Continue,
+            };
+        }
+        self.key_sequence.clear();
         if let Key::Select(index) = &key {
-            self.sel = (*index).max(1);
-            self.follow_selection = true;
-            self.clamp_sel();
-            self.sync_sel_pane();
+            self.select_index(*index);
             return DispatchResult::Continue;
         }
         match dispatch_mode(self.overlay.as_ref(), self.search_focused) {
@@ -965,6 +1042,8 @@ impl Sidebar {
             DispatchMode::Normal => {}
         }
         match key {
+            Key::First => self.select_index(1),
+            Key::Last => self.select_index(self.visible.len()),
             Key::Down => self.move_sel(1),
             Key::Up => self.move_sel(-1),
             Key::WheelUp => self.scroll_viewport(-1),
@@ -1000,7 +1079,12 @@ impl Sidebar {
                 }
                 return DispatchResult::Break;
             }
-            Key::Backspace | Key::ClearSearch | Key::Text(_) | Key::Select(_) | Key::Other => {}
+            Key::Sequence(_)
+            | Key::Backspace
+            | Key::ClearSearch
+            | Key::Text(_)
+            | Key::Select(_)
+            | Key::Other => {}
         }
         DispatchResult::Continue
     }
@@ -1082,11 +1166,15 @@ impl Sidebar {
         Some(crate::focus::parse_clients(&out, focus_events))
     }
 
-    fn move_sel(&mut self, d: i64) {
-        self.sel = (self.sel as i64 + d).max(1) as usize;
+    fn select_index(&mut self, index: usize) {
+        self.sel = index.max(1);
         self.follow_selection = true;
         self.clamp_sel();
         self.sync_sel_pane();
+    }
+
+    fn move_sel(&mut self, d: i64) {
+        self.select_index((self.sel as i64 + d).max(1) as usize);
     }
 
     fn scroll_viewport(&mut self, d: i64) {
@@ -1195,7 +1283,10 @@ impl Sidebar {
             Key::WheelUp => self.scroll_viewport(-1),
             Key::WheelDown => self.scroll_viewport(1),
             Key::AllStates => self.clear_filter(),
-            Key::Select(_)
+            Key::First
+            | Key::Last
+            | Key::Select(_)
+            | Key::Sequence(_)
             | Key::Search
             | Key::CycleState
             | Key::Help
@@ -1781,6 +1872,7 @@ impl Sidebar {
  {E}[32m⣿{E}[0m  done, not viewed yet (blinks)\n\n\
 {E}[1mkeys{E}[0m\n\
  j/k ↑/↓  move selection\n\
+ gg/G     first/last visible agent\n\
  Enter/l  jump to agent\n\
  /        live search; Enter enables j/k\n\
  f        select next state filter\n\
@@ -2006,6 +2098,12 @@ mod tests {
         }
         feed(b"j");
         assert!(matches!(read_key(fds[0]), Key::Down));
+        feed(b"g");
+        assert!(matches!(read_key(fds[0]), Key::Sequence('g')));
+        feed(&[0x06, b'g']);
+        assert!(matches!(read_key(fds[0]), Key::Sequence('g')));
+        feed(b"G");
+        assert!(matches!(read_key(fds[0]), Key::Last));
         feed(&[0x01]);
         assert!(matches!(read_key(fds[0]), Key::WheelUp));
         feed(&[0x02]);
@@ -2018,6 +2116,50 @@ mod tests {
             libc::close(fds[0]);
             libc::close(fds[1]);
         }
+    }
+
+    #[test]
+    fn timed_key_sequences_support_arbitrary_bindings_and_expiry() {
+        let bindings = [("gg", Key::First), ("gd", Key::Last)];
+        let start = Instant::now();
+        let mut sequence = KeySequence::default();
+
+        assert!(matches!(
+            sequence.push('g', start, &bindings),
+            SequenceResult::Pending
+        ));
+        assert!(matches!(
+            sequence.push('d', start + Duration::from_millis(10), &bindings),
+            SequenceResult::Match(Key::Last)
+        ));
+        assert!(matches!(
+            sequence.push('g', start + Duration::from_millis(20), &bindings),
+            SequenceResult::Pending
+        ));
+        assert!(matches!(
+            sequence.push('x', start + Duration::from_millis(30), &bindings),
+            SequenceResult::Miss
+        ));
+        assert!(matches!(
+            sequence.push('g', start + Duration::from_millis(40), &bindings),
+            SequenceResult::Pending
+        ));
+        assert!(matches!(
+            sequence.push(
+                'g',
+                start + KEY_SEQUENCE_TIMEOUT + Duration::from_millis(41),
+                &bindings
+            ),
+            SequenceResult::Pending
+        ));
+        assert!(matches!(
+            sequence.push(
+                'g',
+                start + KEY_SEQUENCE_TIMEOUT + Duration::from_millis(50),
+                &bindings
+            ),
+            SequenceResult::Match(Key::First)
+        ));
     }
 
     /// Feed escape_key a scripted tail. Every byte goes through the same

--- a/src/toggle.rs
+++ b/src/toggle.rs
@@ -118,7 +118,7 @@ fn split(plugin_dir: &Path, client: Option<String>) -> i32 {
             return 1;
         }
     }
-    if option("@agenmux-nav-version") != "12" && setup::run(plugin_dir) != 0 {
+    if option("@agenmux-nav-version") != "13" && setup::run(plugin_dir) != 0 {
         return 1;
     }
     select_sidebar(client.as_deref());

--- a/tests/navigation.sh
+++ b/tests/navigation.sh
@@ -108,8 +108,10 @@ env TMPDIR="$tmp" TMUX="$sock,$server_pid,0" AGENMUX_DIR="$DIR" \
 # user's root binding and install synchronous search delivery before use.
 normal_keys="$(tmux -S "$sock" list-keys -T agenmux)"
 search_keys="$(tmux -S "$sock" list-keys -T agenmux-search)"
-[ "$(tmux -S "$sock" show-option -gqv @agenmux-nav-version)" = 12 ] &&
+[ "$(tmux -S "$sock" show-option -gqv @agenmux-nav-version)" = 13 ] &&
   printf '%s' "$normal_keys" | grep -Fq 'C-l' &&
+  printf '%s' "$normal_keys" | grep -Fq " key 'sequence-67'" &&
+  printf '%s' "$normal_keys" | grep -Fq " key 'last'" &&
   printf '%s' "$normal_keys" | grep -Fq " key 'search'" &&
   printf '%s' "$search_keys" | grep -Fq 'text-6A' || {
   echo "FAIL navigation-key-table: native setup contract missing"
@@ -583,6 +585,28 @@ scrollbar_works=0
 if printf '%s\n' "$scrollbar_frame" | grep -Fq '▐'; then
   scrollbar_works=1
 fi
+edge_first="$(awk '$3 == 1 { print $1; exit }' "$tmp/agenmux-rows")"
+edge_top="$(sed -n '1p' "$tmp/agenmux-rows")"
+printf 'G' >&9
+edge_long_list_works=0
+for _ in $(seq 1 30); do
+  edge_last="$(awk '$3 == 1 { print $1; exit }' "$tmp/agenmux-rows")"
+  edge_last_top="$(sed -n '1p' "$tmp/agenmux-rows")"
+  [ -n "$edge_last" ] && [ "$edge_last" != "$edge_first" ] &&
+    [ "$edge_last_top" != "$edge_top" ] && break
+  sleep 0.05
+done
+printf 'gg' >&9
+for _ in $(seq 1 30); do
+  edge_restored="$(awk '$3 == 1 { print $1; exit }' "$tmp/agenmux-rows")"
+  edge_restored_top="$(sed -n '1p' "$tmp/agenmux-rows")"
+  if [ -n "$edge_first" ] && [ "$edge_restored" = "$edge_first" ] &&
+    [ "$edge_restored_top" = "$edge_top" ]; then
+    edge_long_list_works=1
+    break
+  fi
+  sleep 0.05
+done
 for _ in $(seq 1 20); do
   wheel_up="$(tmux -S "$sock" capture-pane -p -t "$sidebar" |
     sed -n '/❯/p' | head -n 1)"
@@ -622,6 +646,19 @@ if [ "$overflow_agents" -gt 32 ] &&
   [ "$wheel_up" = "$wheel_selected" ]; then
   wheel_delay_works=1
 fi
+printf 'j' >&9
+for _ in $(seq 1 20); do
+  slow_gg_before="$(awk '$3 == 1 { print $1; exit }' "$tmp/agenmux-rows")"
+  [ -n "$slow_gg_before" ] && [ "$slow_gg_before" != "$edge_first" ] && break
+  sleep 0.05
+done
+printf 'g' >&9
+sleep 1.2
+printf 'g' >&9
+sleep 0.2
+slow_gg_after="$(awk '$3 == 1 { print $1; exit }' "$tmp/agenmux-rows")"
+slow_gg_expires=0
+[ -n "$slow_gg_before" ] && [ "$slow_gg_after" = "$slow_gg_before" ] && slow_gg_expires=1
 tmux -S "$sock" set-option -gu @agenmux-wheel-jump
 tmux -S "$sock" list-windows -t navigation -F '#{window_id}	#{window_name}' |
   awk -F '\t' '$2 ~ /^overflow-/ { print $1 }' |
@@ -693,6 +730,24 @@ for _ in $(seq 1 20); do
 done
 accepted_cursor="$(tmux -S "$sock" capture-pane -p -t "$sidebar" |
   sed -n '/❯/p' | head -n 1)"
+printf 'G' >&9
+search_edges_work=0
+for _ in $(seq 1 20); do
+  search_last="$(tmux -S "$sock" capture-pane -p -t "$sidebar" |
+    sed -n '/❯/p' | head -n 1)"
+  [ -n "$search_last" ] && [ "$search_last" != "$accepted_cursor" ] && break
+  sleep 0.05
+done
+printf 'gg' >&9
+for _ in $(seq 1 20); do
+  search_first="$(tmux -S "$sock" capture-pane -p -t "$sidebar" |
+    sed -n '/❯/p' | head -n 1)"
+  if [ -n "$accepted_cursor" ] && [ "$search_first" = "$accepted_cursor" ]; then
+    search_edges_work=1
+    break
+  fi
+  sleep 0.05
+done
 printf 'j' >&9
 search_jk_works=0
 for _ in $(seq 1 20); do
@@ -759,6 +814,26 @@ for _ in $(seq 1 20); do
   if [ "$idle_targets" -eq 2 ] &&
     printf '%s' "$idle_frame" | grep -Fq '[idle]'; then
     idle_filter_works=1
+    break
+  fi
+  sleep 0.05
+done
+state_first="$(tmux -S "$sock" capture-pane -p -t "$sidebar" |
+  sed -n '/❯/p' | head -n 1)"
+printf 'G' >&9
+state_edges_work=0
+for _ in $(seq 1 20); do
+  state_last="$(tmux -S "$sock" capture-pane -p -t "$sidebar" |
+    sed -n '/❯/p' | head -n 1)"
+  [ -n "$state_last" ] && [ "$state_last" != "$state_first" ] && break
+  sleep 0.05
+done
+printf 'gg' >&9
+for _ in $(seq 1 20); do
+  state_restored="$(tmux -S "$sock" capture-pane -p -t "$sidebar" |
+    sed -n '/❯/p' | head -n 1)"
+  if [ -n "$state_first" ] && [ "$state_restored" = "$state_first" ]; then
+    state_edges_work=1
     break
   fi
   sleep 0.05
@@ -926,11 +1001,15 @@ if [ "$table" = agenmux ] && [ "$initial_focus" = agenmux ] &&
   [ "$wheel_up" = "$wheel_selected" ] &&
   [ "$wheel_delay_works" -eq 1 ] &&
   [ "$scrollbar_works" -eq 1 ] &&
+  [ "$edge_long_list_works" -eq 1 ] &&
+  [ "$slow_gg_expires" -eq 1 ] &&
   [ "$return_table" = agenmux ] && [ "$return_focus" = agenmux ] &&
   [ "$fourth" != "$third" ] && [ "$search_works" -eq 1 ] &&
   [ "$search_accept_works" -eq 1 ] && [ "$search_jk_works" -eq 1 ] &&
+  [ "$search_edges_work" -eq 1 ] &&
   [ "$search_blur_works" -eq 1 ] && [ "$blocked_filter_works" -eq 1 ] &&
   [ "$working_filter_works" -eq 1 ] && [ "$idle_filter_works" -eq 1 ] &&
+  [ "$state_edges_work" -eq 1 ] &&
   [ "$all_filter_works" -eq 1 ] &&
   [ "$exit_table" = root ] && [ "$q_left" -eq 1 ] &&
   [ "$escape_ready" -eq 1 ] && [ "$escape_reset" -eq 1 ] &&
@@ -940,6 +1019,7 @@ if [ "$table" = agenmux ] && [ "$initial_focus" = agenmux ] &&
   [ "$notification_stale_noop" -eq 1 ]; then
   echo "ok   attached-client-jk-navigation"
 else
+  echo "edge-nav: long=$edge_long_list_works slow=$slow_gg_expires search=$search_edges_work state=$state_edges_work"
   echo "FAIL navigation-key-table: table=$table initial-focus=[$initial_focus] initial-hint=[$inactive_hint_hidden/$initial_hint] chooser=[$chooser_open_unzoomed/$chooser_state/$chooser_width] ctrl-l=[$ctrl_l_works/$ctrl_l_table/$ctrl_l_focus] missing-client=[$missing_client_noop/$missing_client_table/$missing_secondary_table/$missing_client_focus] empty-click=[$empty_click_works/$empty_click_table/$secondary_click_table/$empty_click_focus/green=$empty_click_green] stale-click=[$stale_click_works/$stale_click_table/$stale_click_focus] non-agent=[$non_agent_locations_work/$location_table/$location_focus] agent-missing-client=[$agent_missing_client_noop/$agent_missing_primary_table/$agent_missing_secondary_table/$agent_missing_focus] vanished-sidebar=[$vanished_sidebar_noop/$vanished_sidebar_table/$vanished_sidebar_focus] valid-click=[$valid_click_works/$valid_click_table/$valid_click_focus/$valid_target] picker=[$picker_open/click=$picker_click_works/$picker_click_table/$picker_click_focus/rows=$picker_click_rows/frame=$picker_click_first/$picker_reclaimed/$picker_table/$picker_before/$picker_return] after-j=$table_after_j control=[$control/$control_flags] first=[$first] second=[$second] third=[$third] wheel=[$wheel_down/$wheel_up/scroll=$wheel_delay_works/top=$wheel_top_before->$wheel_top_after->$wheel_top_restored/focus=$wheel_focus] return=[$return_table/$return_focus] fourth=[$fourth] search=[$search_works/$search_targets/$search_table/$search_frame/$search_hint/accept=$search_accept_works/$accept_table/$accept_frame/$accept_hint/jk=$search_jk_works/$accepted_cursor/$filtered_cursor/blur=$search_blur_works/$blur_table/$blur_targets] filters=[$blocked_filter_works/$blocked_targets/$blocked_frame/$blocked_hint/$working_filter_works/$working_targets/$working_frame/$idle_filter_works/$idle_targets/$idle_frame/$all_filter_works/$all_targets/$all_frame] q-leave=[$q_left/$exit_table/$exit_focus] escape=[$escape_ready/$escape_reset/$escape_left/$escape_table/$escape_focus/$escape_frame] Q-close=[$close_ready/$q_closed/$close_table] notification-open=[$notification_open_works/$notification_stale_noop/$notification_client]"
   exit 1
 fi

--- a/tests/plugin.rs
+++ b/tests/plugin.rs
@@ -557,6 +557,8 @@ fn setup_preserves_root_bindings_and_installs_plugin_tables() {
         normal.contains("run-shell -b") && normal.contains(" key \'j\'"),
         "{normal}"
     );
+    assert!(normal.contains(" key \'sequence-67\'"), "{normal}");
+    assert!(normal.contains(" key \'last\'"), "{normal}");
     let search_action = normal
         .lines()
         .find(|line| line.contains(" key \'search\'"))
@@ -589,7 +591,7 @@ fn setup_preserves_root_bindings_and_installs_plugin_tables() {
     assert!(!text_action.contains("run-shell -b"), "{text_action}");
     assert_eq!(
         tmux.text(&["show-option", "-gqv", "@agenmux-nav-version"]),
-        "12"
+        "13"
     );
     let status = tmux.tmux(&["show-option", "-gqv", "status-right"]);
     assert_success(status.clone(), "show status-right");


### PR DESCRIPTION
## Summary
- add `gg` and `G` shortcuts for first/last visible agents
- use a reusable timed key-sequence matcher so slow `g…g` expires
- preserve search text entry and navigate active search/state projections

## Tests
- `rustup run stable cargo test --locked`
- `rustup run stable cargo build --release --locked`
- `AGENMUX_BIN="$PWD/target/release/agenmux" ./tests/run.sh`

Closes #45
