### PR TITLE
Stop the notifier broker burning CPU on dismissal polling

### DIFF
--- a/src/bin/agenmux-notifier/broker.rs
+++ b/src/bin/agenmux-notifier/broker.rs
@@ -29,6 +29,10 @@ const CLIENT_IO_TIMEOUT: Duration = Duration::from_secs(2);
 const SUBMIT_RETRY_INTERVAL: Duration = Duration::from_millis(50);
 const SUBMIT_RETRY_WINDOW: Duration = Duration::from_secs(5);
 const BROKER_RESPAWN_INTERVAL: Duration = Duration::from_secs(1);
+/// Auto-close untouched notifications. Without a timeout, buttonless
+/// notifications fall back to polling every delivered notification over XPC
+/// every 500ms, per notification -- O(N^2) work that pinned usernotificationd.
+const NOTIFICATION_TIMEOUT: Duration = Duration::from_secs(600);
 
 #[cfg(any(target_os = "macos", test))]
 type PendingNotification = Pin<Box<dyn Future<Output = PendingResult>>>;
@@ -360,7 +364,8 @@ fn pending(request: NotificationRequest) -> PendingNotification {
         let notification = noti::Notification::new()
             .title(&request.title)
             .message(&request.body)
-            .sound(noti::sound::GLASS);
+            .sound(noti::sound::GLASS)
+            .timeout(NOTIFICATION_TIMEOUT);
         let response = match notification.send().await {
             Ok(handle) => handle.response().await,
             Err(error) => Err(error),


### PR DESCRIPTION
## Problem

`agenmux-notifier --broker` was sitting at ~17% of a core permanently while idle, and dragging `usernotificationd` to 25% with it. Over 5.5 days one broker accumulated **13.7 hours of CPU**.

Sampling showed its `com.apple.NSXPCConnection` dispatch queue pegged at 100%, doing nothing but NSXPC deserialization (`_getASCIIStringAtMarker`, `NSXPCSerializationCreateObjectInDictionaryForKey`, `_iterateDictionaryKeysAndValues`).

## Cause

`mac-usernotifications` has a fallback for buttonless notifications, which get no dismissal callback from macOS:

```rust
const DISMISS_POLL_INTERVAL: Duration = Duration::from_millis(500);

async fn poll_until_dismissed(notification_id: String) -> Result<NotificationResponse, Error> {
    loop {
        futures_timer::Delay::new(DISMISS_POLL_INTERVAL).await;
        let delivered = get_delivered_notification_ids().await;  // XPC-fetches ALL delivered
        if !delivered.contains(&notification_id) { ... }
    }
}
```

The broker sent notifications with no actions and no timeout, so it took that branch. Every notification spawned its own 500 ms loop, and each iteration XPC-fetched and deserialized *every* delivered notification. macOS caps delivered notifications at 100 per app, so at saturation that is ~100 polls/sec x 100 objects = **~20,000 deserializations/sec**. The cost is O(N^2) in undismissed notifications and grows the longer the broker lives.

It also explains why the broker never exited: `pending` never drained, so `should_exit()` was never true.

## Fix

Set a timeout on the notification. That takes the crate's *other* branch — a single `Delay` followed by `close_delivered`, with no polling at all — and lets `pending` drain so the broker exits when idle as designed.

```rust
const NOTIFICATION_TIMEOUT: Duration = Duration::from_secs(600);
```

## Trade-off

Notifications now auto-close after 10 minutes, so clicking one to jump to its pane only works within that window. The alternative fix — giving notifications an action button — also bypasses the poll loop and keeps them indefinitely, at the cost of a visible button. Happy to switch if that is preferred.

## Measured

Idle, same machine, before vs after:

| process | before | after |
|---|---|---|
| `agenmux-notifier --broker` | 17.4% | **0.0%** |
| `usernotificationd` | 25.0% | **0.0%** |
| `usernoted` | 3.4% | **0.0%** |

Verified with a live pending notification present: `0.00 cpu-s/60s`.

## Checklist

- [x] `cargo test` passes (115 tests across all binaries)
- [x] `tests/run.sh` passes, including `install-app-assembles-signed-bundle`
- [ ] New/changed detection has a fixture behind it — n/a, no detection change
- [ ] README updated — n/a, no new option; behaviour change noted above
- [x] One focused change per PR

Note: building requires Rust 1.90+ per `CONTRIBUTING.md`; verified with 1.98.0.