### PR TITLE
Fix fragmented sidebar scrollbar on full-width rows

### DIFF
--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -81,10 +81,23 @@ fn clip_frame(frame: &str, cols: usize, cap: usize) -> String {
             if let Some(next) = chars.next() {
                 out.push(next);
                 if next == '[' {
+                    let mut csi_column = 0usize;
+                    let mut column_only = true;
+                    let mut saw_digit = false;
                     for parameter in chars.by_ref() {
                         out.push(parameter);
-                        if ('@'..='~').contains(&parameter) {
+                        if parameter.is_ascii_digit() && column_only {
+                            saw_digit = true;
+                            csi_column = csi_column
+                                .saturating_mul(10)
+                                .saturating_add(parameter as usize - '0' as usize);
+                        } else if ('@'..='~').contains(&parameter) {
+                            if parameter == 'G' && column_only {
+                                col = if saw_digit { csi_column } else { 1 }.saturating_sub(1);
+                            }
                             break;
+                        } else {
+                            column_only = false;
                         }
                     }
                 }
@@ -2757,7 +2770,11 @@ mod tests {
                                 sb.daemon.as_mut().unwrap().size = size;
                                 sb.render(true);
                                 let text = plain(&sb.last_frame);
-                                assert!(text.lines().all(|l| l.chars().count() <= size.0));
+                                let final_column = format!("{E}[{}G", size.0);
+                                assert!(sb.last_frame.lines().zip(text.lines()).all(
+                                    |(frame, text)| text.chars().count()
+                                        <= size.0 + usize::from(frame.contains(&final_column))
+                                ));
                                 assert!(text.lines().count() <= size.1.saturating_sub(1));
                                 assert!(
                                     std::fs::read_to_string(&sb.rows_file)

--- a/tests/navigation.sh
+++ b/tests/navigation.sh
@@ -592,8 +592,11 @@ for _ in $(seq 1 80); do
   sleep 0.1
 done
 scrollbar_frame="$(tmux -S "$sock" capture-pane -p -t "$sidebar")"
+scrollbar_rows="$(wc -l <"$tmp/agenmux-rows")"
+scrollbar_glyph_rows="$(printf '%s\n' "$scrollbar_frame" |
+  awk -v rows="$scrollbar_rows" 'NR > 1 && NR <= rows + 1 && /[│▐]$/ { n++ } END { print n + 0 }')"
 scrollbar_works=0
-if printf '%s\n' "$scrollbar_frame" | grep -Fq '▐'; then
+if [ "$scrollbar_rows" -gt 0 ] && [ "$scrollbar_glyph_rows" -eq "$scrollbar_rows" ]; then
   scrollbar_works=1
 fi
 edge_first="$(awk '$3 == 1 { print $1; exit }' "$tmp/agenmux-rows")"


### PR DESCRIPTION
## Summary

- track CSI horizontal absolute cursor moves while clipping sidebar frames
- keep overflow scrollbar glyphs on full-width rows
- require every rendered overflow viewport row to end with a track or thumb glyph

## Testing

- `cargo test`
- `AGENMUX_BIN=target/debug/agenmux bash tests/navigation.sh`
- active dev binary switched to this worktree for live testing

Fixes #65
