### PR TITLE
Fix focused sidebar startup loading

### DIFF
--- a/src/scan.rs
+++ b/src/scan.rs
@@ -5,7 +5,7 @@ use crate::procs::{self, IdentCache, Snapshot};
 use crate::tmux::{Tmux, TmuxError};
 use std::collections::HashMap;
 
-/// pane -> (cwd, SUBJECT_CMD output). The sidebar loop must stay fork-free:
+/// pane -> (cwd, SUBJECT_CMD output). Startup seeds may hold cwd basename;
 /// entries live while the pane sits idle and drop on any state change (a new
 /// prompt flips the pane to working), so the fork re-runs only when the
 /// subject could actually have changed.
@@ -152,8 +152,17 @@ pub fn scan(
         if state != "idle" {
             subj.remove(pane); // pane got a new prompt — cached subject is stale
         } else if subject.is_empty() && confs[idx].subject_cmd.is_some() {
-            match subj.get(pane).filter(|(cwd, _)| cwd == path) {
-                Some((_, s)) => subject = s.clone(),
+            let cached = subj
+                .get(pane)
+                .filter(|(cwd, _)| {
+                    cwd == path || cwd == path.rsplit('/').next().unwrap_or(path)
+                })
+                .map(|(_, subject)| subject.clone());
+            match cached {
+                Some(cached) => {
+                    subject = cached;
+                    subj.insert(pane.to_string(), (path.to_string(), subject.clone()));
+                }
                 None => {
                     let t0 = std::time::Instant::now();
                     let started = procs::agent_start(&confs[idx], &mut snap, pid);

--- a/src/sidebar.rs
+++ b/src/sidebar.rs
@@ -139,6 +139,22 @@ fn new_sidebar(
     // restarts the engine anyway
     let update = update_available(&plugin_dir);
     let adopted_show_all_panes = settings.show_all_panes;
+    let cached_rows = std::fs::read_to_string(&cache_file)
+        .map(|tsv| scan::from_tsv(&tsv))
+        .unwrap_or_default();
+    // Cached TSV stores cwd basename, enough to avoid blocking startup on
+    // unchanged panes. Live scans upgrade matching entries to full paths.
+    // ponytail: basename can collide; persist full cwd if cache format changes.
+    let seeded_subjects = cached_rows
+        .iter()
+        .filter(|row| row.pane != self_pane && !row.title.is_empty())
+        .map(|row| {
+            (
+                row.pane.clone(),
+                (row.cwd.clone(), row.title.clone()),
+            )
+        })
+        .collect();
     let mut sb = Sidebar {
         tmux,
         palette: Palette::resolve(&settings.theme),
@@ -148,7 +164,7 @@ fn new_sidebar(
         adopted_show_all_panes,
         confs,
         ident: IdentCache::new(),
-        subj: scan::SubjectCache::new(),
+        subj: seeded_subjects,
         tracker: Tracker::default(),
         rows: Vec::new(),
         panes: Vec::new(),
@@ -179,12 +195,10 @@ fn new_sidebar(
         daemon: None,
         overlay: None,
     };
-    // seed from the previous instance's scan for an instant first frame
+    // Agent-only mode can show the whole cached projection immediately.
     if !sb.settings.settings.show_all_panes {
-        if let Ok(tsv) = std::fs::read_to_string(&sb.cache_file) {
-            sb.rows = scan::from_tsv(&tsv);
-            sb.rows.retain(|r| r.pane != sb.self_pane);
-        }
+        sb.rows = cached_rows;
+        sb.rows.retain(|r| r.pane != sb.self_pane);
     }
     sb.rebuild_visible(false);
     sb

--- a/src/toggle.rs
+++ b/src/toggle.rs
@@ -145,12 +145,12 @@ fn split(plugin_dir: &Path, client: Option<String>, config: &crate::app_config::
             .map(|name| runtime.join(name))
             .into_iter().filter(|path| !path.exists()).collect::<Vec<_>>();
         let result = (|| {
-            // Record only panes made by this activation, not arbitrary panes
-            // that appear while the daemon is starting.
-            for window in tmux::lines(&["list-windows", "-a", "-F", "#{window_id}"])
-                .map_err(|_| "cannot enumerate startup windows")? {
-                if panes::pane_add_record(Some(&window), config, &mut created) != 0 {
-                    return Err("cannot create startup pane");
+            let mut windows = tmux::lines(&["list-windows", "-a", "-F", "#{window_id}"])
+                .map_err(|_| "cannot enumerate startup windows")?;
+            if let Some(focused) = window.as_deref() {
+                if let Some(index) = windows.iter().position(|candidate| candidate == focused) {
+                    let focused = windows.remove(index);
+                    windows.insert(0, focused);
                 }
             }
             child = Some(Command::new(&bin)
@@ -161,6 +161,14 @@ fn split(plugin_dir: &Path, client: Option<String>, config: &crate::app_config::
                 .stdout(Stdio::piped())
                 .stderr(Stdio::null())
                 .spawn().map_err(|_| "cannot launch daemon; check executable")?);
+            // Record only panes made by this activation, not arbitrary panes
+            // that appear while the daemon is starting. The focused window goes
+            // first so its sidebar can render while the remaining panes fan out.
+            for window in windows {
+                if panes::pane_add_record(Some(&window), config, &mut created) != 0 {
+                    return Err("cannot create startup pane");
+                }
+            }
             await_daemon(child.as_mut().unwrap())?;
             if setup::run_config(plugin_dir, config) != 0 { return Err("daemon setup failed"); }
             if child.as_mut().unwrap().try_wait().map_err(|_| "cannot observe daemon")?.is_some() {

--- a/tests/pane_lock.rs
+++ b/tests/pane_lock.rs
@@ -295,6 +295,12 @@ fn public_pane_lock_recovers_bounds_contention_and_rolls_back() {
 
     // Startup creates @0 then times out on @1. It must roll back only its
     // own split, restore layout, and clear activation/daemon options.
+    server.assert_tmux(&[
+        "set-option",
+        "-g",
+        "@agenmux-bin",
+        env!("CARGO_BIN_EXE_agenmux"),
+    ]);
     let (owner, _) = pause_pane_add(&server, &other, "rollback-owner");
     let layout = server.text(&["display-message", "-p", "-t", "@0", "#{window_layout}"]);
     let error = pane_lock_run(&server, &["toggle", "split"], 1);

--- a/tests/plugin.rs
+++ b/tests/plugin.rs
@@ -1833,6 +1833,147 @@ fn sidebar_refresh_uses_one_content_enumeration() {
 }
 
 #[test]
+fn startup_populates_the_focused_sidebar_before_fanning_out() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmux = TestTmux::new("focused-startup");
+    tmux.assert_tmux(&["rename-window", "-t", "plugin:0", "ordinary"]);
+    let codex = tmux.tmp.join("codex");
+    std::fs::write(&codex, "#!/bin/sh\nwhile :; do sleep 60; done\n").unwrap();
+    std::fs::set_permissions(&codex, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let agent = tmux.text(&[
+        "new-window",
+        "-d",
+        "-P",
+        "-F",
+        "#{pane_id}",
+        "-t",
+        "plugin:",
+        "-n",
+        "focused",
+        codex.to_str().unwrap(),
+    ]);
+    tmux.assert_tmux(&["select-pane", "-t", &agent, "-T", "codex"]);
+    let cwd = tmux.text(&["display-message", "-p", "-t", &agent, "#{pane_current_path}"]);
+    let cwd_name = PathBuf::from(&cwd)
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .into_owned();
+    let plugin_dir = tmux.tmp.join("plugin");
+    std::fs::create_dir_all(plugin_dir.join("agents")).unwrap();
+    std::fs::write(
+        plugin_dir.join("agents/codex.conf"),
+        "AGENT_BINS='codex'\nSUBJECT_CMD='sleep 3; printf slow'\n",
+    )
+    .unwrap();
+    std::fs::write(
+        tmux.tmp.join("agenmux-scan-cache"),
+        format!("{agent}\tprobe:1.0\tcodex\tidle\t{cwd_name}\tcached subject\n"),
+    )
+    .unwrap();
+    tmux.assert_tmux(&[
+        "new-window",
+        "-d",
+        "-t",
+        "plugin:",
+        "-n",
+        "tail",
+        "exec sleep 60",
+    ]);
+    app_file(
+        &tmux,
+        "[display]\nshow_all_panes=true\n[behavior]\nnotifications=false",
+    );
+    tmux.assert_tmux(&[
+        "set-option",
+        "-g",
+        "@agenmux-bin",
+        env!("CARGO_BIN_EXE_agenmux"),
+    ]);
+
+    let mut viewer = tmux.attach();
+    tmux.wait_for(Duration::from_secs(2), || {
+        !tmux
+            .text(&["list-clients", "-F", "#{client_name}"])
+            .is_empty()
+    });
+    let client = tmux.text(&["list-clients", "-F", "#{client_name}"]);
+    tmux.assert_tmux(&["switch-client", "-c", &client, "-t", &agent]);
+    let focused_window = tmux.text(&["display-message", "-p", "-t", &agent, "#{window_id}"]);
+
+    let stubs = tmux.tmp.join("stubs");
+    std::fs::create_dir_all(&stubs).unwrap();
+    let real_tmux = String::from_utf8(Command::new("which").arg("tmux").output().unwrap().stdout)
+        .unwrap()
+        .trim()
+        .to_string();
+    let split_count = tmux.tmp.join("split-count");
+    let blocked = tmux.tmp.join("second-split-blocked");
+    let release = tmux.tmp.join("release-second-split");
+    std::fs::write(
+        stubs.join("tmux"),
+        format!(
+            "#!/bin/sh\nif printf '%s\\n' \"$*\" | grep -q 'split-window -I'; then\n  count=$(cat '{}' 2>/dev/null || echo 0)\n  count=$((count + 1))\n  printf '%s\\n' \"$count\" > '{}'\n  if [ \"$count\" = 2 ]; then\n    : > '{}'\n    while [ ! -e '{}' ]; do sleep 0.01; done\n  fi\nfi\nexec '{}' \"$@\"\n",
+            split_count.display(),
+            split_count.display(),
+            blocked.display(),
+            release.display(),
+            real_tmux.replace('\'', "'\\''"),
+        ),
+    )
+    .unwrap();
+    std::fs::set_permissions(stubs.join("tmux"), std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let child = tmux
+        .bin_command(&["toggle", "split", &client])
+        .env(
+            "PATH",
+            format!("{}:{}", stubs.display(), std::env::var("PATH").unwrap()),
+        )
+        .env("AGENMUX_DIR", &plugin_dir)
+        .spawn()
+        .unwrap();
+    tmux.wait_for(Duration::from_secs(3), || blocked.exists());
+    let sidebar_windows = tmux.text(&[
+        "list-panes",
+        "-a",
+        "-f",
+        "#{==:#{pane_title},agenmux}",
+        "-F",
+        "#{window_id}",
+    ]);
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let mut loaded_before_fanout = false;
+    while Instant::now() < deadline {
+        if std::fs::read_to_string(tmux.tmp.join("agenmux-rows"))
+            .unwrap_or_default()
+            .contains(&agent)
+        {
+            loaded_before_fanout = true;
+            break;
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+    std::fs::write(&release, "").unwrap();
+    let output = child.wait_with_output().unwrap();
+    let first_sidebar_was_focused = sidebar_windows == focused_window;
+
+    assert_success(output, "start focused sidebar");
+    assert!(
+        first_sidebar_was_focused,
+        "first sidebar was {sidebar_windows}, focused window was {focused_window}"
+    );
+    assert!(
+        loaded_before_fanout,
+        "focused sidebar had no agent data while remaining panes were blocked"
+    );
+    assert_success(tmux.bin(&["key", "close"]), "close focused sidebar");
+    let _ = viewer.kill();
+    let _ = viewer.wait();
+}
+
+#[test]
 fn binary_helper_uses_private_server() {
     let tmux = TestTmux::new("binary-helper");
     assert_success(tmux.bin(&["status"]), "agenmux status");


### PR DESCRIPTION
## Summary
- create focused window sidebar before other mirrors
- start daemon while remaining sidebar panes fan out
- seed subject cache from prior scan so slow subject commands do not block first full-pane render

## Verification
- `mise exec rust@latest -- cargo test --locked`
- live 28-window startup: focused sidebar 224ms, agent rows 352ms (previous cold scan 12.4s)
